### PR TITLE
Added ps_process_cep to swig python interface

### DIFF
--- a/swig/pocketsphinx.i
+++ b/swig/pocketsphinx.i
@@ -78,7 +78,6 @@ typedef fsg_model_t FsgModel;
 typedef logmath_t LogMath;
 typedef ngram_model_t NGramModel;
 typedef ngram_model_t NGramModelSet;
-typedef mfcc_t Mfcc;
 %}
 
 %begin %{

--- a/swig/pocketsphinx.i
+++ b/swig/pocketsphinx.i
@@ -78,6 +78,7 @@ typedef fsg_model_t FsgModel;
 typedef logmath_t LogMath;
 typedef ngram_model_t NGramModel;
 typedef ngram_model_t NGramModelSet;
+typedef mfcc_t Mfcc;
 %}
 
 %begin %{

--- a/swig/ps_decoder.i
+++ b/swig/ps_decoder.i
@@ -124,14 +124,14 @@
         process_cep(const void *SDATA, size_t NSAMP, bool no_search, bool full_utt,
                 int *errcode) {
         int ncep = fe_get_output_size(ps_get_fe($self));
-        NSAMP /= ncep * sizeof(Mfcc);
-        Mfcc ** input = (Mfcc**) malloc(NSAMP*sizeof(Mfcc*));
+        NSAMP /= ncep * sizeof(mfcc_t);
+        mfcc_t ** input = (mfcc_t**) malloc(NSAMP*sizeof(mfcc_t*));
         int i, j;
         for (i = 0; i < NSAMP; i++)
-            input[i] = (Mfcc*) malloc(ncep * sizeof(Mfcc));
+            input[i] = (mfcc_t*) malloc(ncep * sizeof(mfcc_t));
         for (i = 0; i < NSAMP; i++)
             for (j = 0; j < ncep; j++)
-                input[i][j] = ((Mfcc*)SDATA)[j+i*ncep];
+                input[i][j] = ((mfcc_t*)SDATA)[j+i*ncep];
         return *errcode = ps_process_cep($self, input, NSAMP, no_search, full_utt);
     }
 #else
@@ -139,11 +139,6 @@
     process_raw(const int16 *SDATA, size_t NSAMP, bool no_search, bool full_utt,
                 int *errcode) {
         return *errcode = ps_process_raw($self, SDATA, NSAMP, no_search, full_utt);
-    }
-    int
-    process_cep(Mfcc **SDATA, size_t NSAMP, bool no_search, bool full_utt,
-                int *errcode) {
-        return *errcode = ps_process_cep($self, SDATA, NSAMP, no_search, full_utt);
     }
 #endif
 

--- a/swig/ps_decoder.i
+++ b/swig/ps_decoder.i
@@ -132,7 +132,11 @@
         for (i = 0; i < NSAMP; i++)
             for (j = 0; j < ncep; j++)
                 input[i][j] = ((mfcc_t*)SDATA)[j+i*ncep];
-        return *errcode = ps_process_cep($self, input, NSAMP, no_search, full_utt);
+        *errcode = ps_process_cep($self, input, NSAMP, no_search, full_utt);
+        for (i = 0; i < NSAMP; i++)
+            free(input[i]);
+        free(input);
+        return *errcode;
     }
 #else
     int

--- a/swig/ps_decoder.i
+++ b/swig/ps_decoder.i
@@ -120,11 +120,30 @@
         NSAMP /= sizeof(int16);
         return *errcode = ps_process_raw($self, SDATA, NSAMP, no_search, full_utt);
     }
+    int
+        process_cep(const void *SDATA, size_t NSAMP, bool no_search, bool full_utt,
+                int *errcode) {
+        int ncep = fe_get_output_size(ps_get_fe($self));
+        NSAMP /= ncep * sizeof(Mfcc);
+        Mfcc ** input = (Mfcc**) malloc(NSAMP*sizeof(Mfcc*));
+        int i, j;
+        for (i = 0; i < NSAMP; i++)
+            input[i] = (Mfcc*) malloc(ncep * sizeof(Mfcc));
+        for (i = 0; i < NSAMP; i++)
+            for (j = 0; j < ncep; j++)
+                input[i][j] = ((Mfcc*)SDATA)[j+i*ncep];
+        return *errcode = ps_process_cep($self, input, NSAMP, no_search, full_utt);
+    }
 #else
     int
     process_raw(const int16 *SDATA, size_t NSAMP, bool no_search, bool full_utt,
                 int *errcode) {
         return *errcode = ps_process_raw($self, SDATA, NSAMP, no_search, full_utt);
+    }
+    int
+    process_cep(Mfcc **SDATA, size_t NSAMP, bool no_search, bool full_utt,
+                int *errcode) {
+        return *errcode = ps_process_cep($self, SDATA, NSAMP, no_search, full_utt);
     }
 #endif
 


### PR DESCRIPTION
This adds ps_process_cep to the Python interface in the SWIG wrapper. It is not great as it copies the values of the feature vectors, and also might not work for the JAVA bindings (not tested).

Input is given as a one-dimensional array where component i of frame j is at `((Mfcc*)SDATA)[i+j*ncep]` with `ncep` being the feature vector length.
