### PR TITLE
python livedemo: GstElement api fix

### DIFF
--- a/src/gst-plugin/livedemo.py
+++ b/src/gst-plugin/livedemo.py
@@ -63,12 +63,12 @@ class DemoApp(object):
         if msgtype != 'pocketsphinx':
             return
 
-        if msg.get_structure()['final']:
-            self.final_result(msg.get_structure()['hypothesis'], msg.get_structure()['confidence'])
+        if msg.get_structure().get_value('final'):
+            self.final_result(msg.get_structure().get_value('hypothesis'), msg.get_structure().get_value('confidence'))
             self.pipeline.set_state(gst.State.PAUSED)
             self.button.set_active(False)
-        elif msg.get_structure()['hypothesis']:
-            self.partial_result(msg.get_structure()['hypothesis'])
+        elif msg.get_structure().get_value('hypothesis'):
+            self.partial_result(msg.get_structure().get_value('hypothesis'))
 
     def partial_result(self, hyp):
         """Delete any previous selection, insert text and select it."""


### PR DESCRIPTION
I was getting the following error on ubuntu 14.10 so this fcommit fix it:

```
Traceback (most recent call last):
  File "src/gst-plugin/livedemo.py", line 66, in element_message
    if msg.get_structure()['final']:
TypeError: 'Structure' object has no attribute '__getitem__'
```