### PR TITLE
gst_pocketsphinx_finalize_utt boolean expression fix

### DIFF
--- a/src/gst-plugin/gstpocketsphinx.c
+++ b/src/gst-plugin/gstpocketsphinx.c
@@ -694,7 +694,7 @@ gst_pocketsphinx_finalize_utt(GstPocketSphinx *ps)
     int32 score;
 
     hyp = NULL;
-    if (!ps->listening_started || !ps->utt_started)
+    if (!ps->listening_started && !ps->utt_started)
 	return;
 
     ps_end_utt(ps->ps);


### PR DESCRIPTION
Ok, in line 649 a new utterance is started ( ps_start_utt() ), but if there were no buffers with speech ( ps_get_in_speech() always returned FALSE ) the gst_pocketsphinx_finalize_utt() function is unable to finalize utterance, because ps->utt_started is still equal to FALSE. In that case gst_pocketsphinx_finalize_utt() simply does nothing and utterance remains unfinished.
This issue causes the situation when user, for example, can't switch from keyword serach to a grammar search after sending the EOS event to the pipeline, because the utterance is not finsihed properly.

