### PR TITLE
Added jsgf/fsg tags extraction

### DIFF
--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -8,7 +8,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -16,16 +16,16 @@
  *    distribution.
  *
  *
- * THIS SOFTWARE IS PROVIDED BY CARNEGIE MELLON UNIVERSITY ``AS IS'' AND 
- * ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+ * THIS SOFTWARE IS PROVIDED BY CARNEGIE MELLON UNIVERSITY ``AS IS'' AND
+ * ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
  * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY
  * NOR ITS EMPLOYEES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * ====================================================================
@@ -61,11 +61,6 @@ extern "C" {
 #if 0
 }
 #endif
-
-/**
- * PocketSphinx hyptags struct.
- */
-typedef struct ps_hyptags_s ps_hyptags_t;
 
 /**
  * PocketSphinx speech recognizer object.
@@ -272,7 +267,7 @@ int ps_add_word(ps_decoder_t *ps,
                 char const *phones,
                 int update);
 
-/** 
+/**
  * Lookup for the word in the dictionary and return phone transcription
  * for it.
  *
@@ -284,7 +279,7 @@ int ps_add_word(ps_decoder_t *ps,
  *         allocated and must be freed by the user.
  */
 POCKETSPHINX_EXPORT
-char *ps_lookup_word(ps_decoder_t *ps, 
+char *ps_lookup_word(ps_decoder_t *ps,
 	             const char *word);
 
 /**
@@ -419,12 +414,21 @@ char const *ps_get_hyp(ps_decoder_t *ps, int32 *out_best_score);
  *
  * @param ps Decoder.
  * @param out_best_score Output: path score corresponding to returned string.
- * @return glist_t containing ps_hyptags_t. Each struct has a word of the best 
- *         hypothesis at this point in decoding, and a glist_t of chars for the tags (can be NULL).
- *          NULL is returned if no hypothesis is available. 
+ * @return glist_t of ps_hyptags_t structs, accessed through iterators below. NULL on error
  */
+
 POCKETSPHINX_EXPORT
 glist_t ps_get_hyp_with_tags(ps_decoder_t *ps, int32 *out_best_score);
+
+/**
+ * Get glist containing tags and word referenced.
+ *
+ * @param glist containing word-tags pairs.
+ * @param referenced word of the hypothesis.
+ *
+ * @return glist_t to hold extracted tags,or NULL on error.
+ */
+glist_t ps_get_word_and_tags(glist_t hyptags_list, char *word);
 
 /**
  * Get posterior probability.
@@ -551,7 +555,7 @@ ps_nbest_t *ps_nbest(ps_decoder_t *ps);
  * @return Updated N-best iterator, or NULL if no more hypotheses are
  *         available (iterator is freed ni this case).
  */
-POCKETSPHINX_EXPORT 
+POCKETSPHINX_EXPORT
 ps_nbest_t *ps_nbest_next(ps_nbest_t *nbest);
 
 /**
@@ -629,7 +633,7 @@ void ps_set_rawdata_size(ps_decoder_t *ps, int32 size);
 
 /**
  * Retrieves the raw data collected during utterance decoding.
- * 
+ *
  * @param ps Decoder
  * @param buffer preallocated buffer to store the data, must be within the limit
  * set before

--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -47,6 +47,7 @@
 #include <sphinxbase/logmath.h>
 #include <sphinxbase/fe.h>
 #include <sphinxbase/feat.h>
+#include <sphinxbase/glist.h>
 
 /* PocketSphinx headers (not many of them!) */
 #include <pocketsphinx_export.h>
@@ -60,6 +61,11 @@ extern "C" {
 #if 0
 }
 #endif
+
+/**
+ * PocketSphinx hyptags struct.
+ */
+typedef struct ps_hyptags_s ps_hyptags_t;
 
 /**
  * PocketSphinx speech recognizer object.
@@ -407,6 +413,18 @@ int ps_end_utt(ps_decoder_t *ps);
  */
 POCKETSPHINX_EXPORT
 char const *ps_get_hyp(ps_decoder_t *ps, int32 *out_best_score);
+
+/**
+ * Get glist containing word-tags pairs, as ps_hyptags_t.
+ *
+ * @param ps Decoder.
+ * @param out_best_score Output: path score corresponding to returned string.
+ * @return glist_t containing ps_hyptags_t. Each struct has a word of the best 
+ *         hypothesis at this point in decoding, and a glist_t of chars for the tags (can be NULL).
+ *          NULL is returned if no hypothesis is available. 
+ */
+POCKETSPHINX_EXPORT
+glist_t ps_get_hyp_with_tags(ps_decoder_t *ps, int32 *out_best_score);
 
 /**
  * Get posterior probability.

--- a/src/libpocketsphinx/allphone_search.c
+++ b/src/libpocketsphinx/allphone_search.c
@@ -131,6 +131,7 @@ static ps_searchfuncs_t allphone_funcs = {
     /* free: */ allphone_search_free,
     /* lattice: */ allphone_search_lattice,
     /* hyp: */ allphone_search_hyp,
+	/* hyptags_list: */ allphone_search_hyp_with_tags,
     /* prob: */ allphone_search_prob,
     /* seg_iter: */ allphone_search_seg_iter,
 };
@@ -906,4 +907,11 @@ allphone_search_hyp(ps_search_t * search, int32 * out_score)
     search->hyp_str[--hyp_idx] = '\0';
     E_INFO("Hyp: %s\n", search->hyp_str);
     return search->hyp_str;
+}
+
+glist_t
+allphone_search_hyp_with_tags(ps_search_t * search, int32 * out_score)
+{
+	E_WARN("Tags extraction for allphone_search not implemented\n");
+	return NULL;
 }

--- a/src/libpocketsphinx/allphone_search.h
+++ b/src/libpocketsphinx/allphone_search.h
@@ -176,4 +176,9 @@ int allphone_search_finish(ps_search_t * search);
  */
 char const *allphone_search_hyp(ps_search_t * search, int32 * out_score);
 
+/**
+ * Get glist_t with word-tags pairs.
+ */
+glist_t allphone_search_hyp_with_tags(ps_search_t * search, int32 * out_score);
+
 #endif                          /* __ALLPHONE_SEARCH_H__ */

--- a/src/libpocketsphinx/fsg_search.c
+++ b/src/libpocketsphinx/fsg_search.c
@@ -1101,7 +1101,7 @@ fsg_search_hyp_with_tags(ps_search_t *search, int32 *out_score)
                                 dict_wordid(dict,
                                             fsg_model_word_str(fsgs->fsg, wid)));
 
-        ps_hyptags_t *r = ckd_calloc(1, sizeof(ps_hyptags_t));
+        ps_hyptags_t *r = (ps_hyptags_t *)ckd_calloc(1, sizeof(ps_hyptags_t));
         r->tags = tags;
         r->word = baseword;
 

--- a/src/libpocketsphinx/fsg_search_internal.h
+++ b/src/libpocketsphinx/fsg_search_internal.h
@@ -150,4 +150,9 @@ int fsg_search_finish(ps_search_t *search);
  */
 char const *fsg_search_hyp(ps_search_t *search, int32 *out_score);
 
+/**
+ * Get glist_t with word-tags pairs.
+ */
+glist_t fsg_search_hyp_with_tags(ps_search_t *search, int32 *out_score);
+
 #endif

--- a/src/libpocketsphinx/kws_search.c
+++ b/src/libpocketsphinx/kws_search.c
@@ -147,6 +147,7 @@ static ps_searchfuncs_t kws_funcs = {
     /* free: */ kws_search_free,
     /* lattice: */ kws_search_lattice,
     /* hyp: */ kws_search_hyp,
+    /* hyptags_list: */ kws_search_hyp_with_tags,
     /* prob: */ kws_search_prob,
     /* seg_iter: */ kws_search_seg_iter,
 };
@@ -673,6 +674,13 @@ kws_search_hyp(ps_search_t * search, int32 * out_score)
     search->hyp_str = kws_detections_hyp_str(kwss->detections, kwss->frame, kwss->delay);
 
     return search->hyp_str;
+}
+
+glist_t
+kws_search_hyp_with_tags(ps_search_t * search, int32 * out_score)
+{
+	E_WARN("Tags extraction for kws_search not implemented\n");
+	return NULL;
 }
 
 char * 

--- a/src/libpocketsphinx/kws_search.h
+++ b/src/libpocketsphinx/kws_search.h
@@ -135,6 +135,11 @@ int kws_search_finish(ps_search_t * search);
 char const *kws_search_hyp(ps_search_t * search, int32 * out_score);
 
 /**
+ * Get glist_t with word-tags pairs.
+ */
+glist_t kws_search_hyp_with_tags(ps_search_t * search, int32 * out_score);
+
+/**
  * Get active keyphrases
  */
 char* kws_search_get_keyphrases(ps_search_t * search);

--- a/src/libpocketsphinx/ngram_search.c
+++ b/src/libpocketsphinx/ngram_search.c
@@ -60,6 +60,7 @@ static int ngram_search_step(ps_search_t *search, int frame_idx);
 static int ngram_search_finish(ps_search_t *search);
 static int ngram_search_reinit(ps_search_t *search, dict_t *dict, dict2pid_t *d2p);
 static char const *ngram_search_hyp(ps_search_t *search, int32 *out_score);
+static glist_t ngram_search_hyp_with_tags(ps_search_t *search, int32 *out_score);
 static int32 ngram_search_prob(ps_search_t *search);
 static ps_seg_t *ngram_search_seg_iter(ps_search_t *search);
 
@@ -71,6 +72,7 @@ static ps_searchfuncs_t ngram_funcs = {
     /* free: */   ngram_search_free,
     /* lattice: */  ngram_search_lattice,
     /* hyp: */      ngram_search_hyp,
+    /* hyptags_list: */ ngram_search_hyp_with_tags,
     /* prob: */     ngram_search_prob,
     /* seg_iter: */ ngram_search_seg_iter,
 };
@@ -885,6 +887,13 @@ ngram_search_hyp(ps_search_t *search, int32 *out_score)
     }
 
     return NULL;
+}
+
+static glist_t
+ngram_search_hyp_with_tags(ps_search_t * search, int32 * out_score)
+{
+    E_WARN("Tags extraction for ngram_search not implemented\n");
+	return NULL;
 }
 
 static void

--- a/src/libpocketsphinx/phone_loop_search.c
+++ b/src/libpocketsphinx/phone_loop_search.c
@@ -49,6 +49,7 @@ static int phone_loop_search_finish(ps_search_t *search);
 static int phone_loop_search_reinit(ps_search_t *search, dict_t *dict, dict2pid_t *d2p);
 static void phone_loop_search_free(ps_search_t *search);
 static char const *phone_loop_search_hyp(ps_search_t *search, int32 *out_score);
+static glist_t phone_loop_search_hyp_with_tags(ps_search_t *search, int32 *out_score);
 static int32 phone_loop_search_prob(ps_search_t *search);
 static ps_seg_t *phone_loop_search_seg_iter(ps_search_t *search);
 
@@ -60,6 +61,7 @@ static ps_searchfuncs_t phone_loop_search_funcs = {
     /* free: */   phone_loop_search_free,
     /* lattice: */  NULL,
     /* hyp: */      phone_loop_search_hyp,
+    /* hyptags_list: */ phone_loop_search_hyp_with_tags,
     /* prob: */     phone_loop_search_prob,
     /* seg_iter: */ phone_loop_search_seg_iter,
 };
@@ -348,6 +350,13 @@ static char const *
 phone_loop_search_hyp(ps_search_t *search, int32 *out_score)
 {
     E_WARN("Hypotheses are not returned from phone loop search");
+    return NULL;
+}
+
+static glist_t
+phone_loop_search_hyp_with_tags(ps_search_t *search, int32 *out_score)
+{
+    E_WARN("hyptags lists are not returned from phone loop search");
     return NULL;
 }
 

--- a/src/libpocketsphinx/pocketsphinx.c
+++ b/src/libpocketsphinx/pocketsphinx.c
@@ -1199,6 +1199,17 @@ ps_get_hyp(ps_decoder_t *ps, int32 *out_best_score)
     return hyp;
 }
 
+glist_t
+ps_get_hyp_with_tags(ps_decoder_t *ps, int32 *out_best_score)
+{
+    glist_t hyptags_list;
+
+    ptmr_start(&ps->perf);
+    hyptags_list = ps_search_hyp_with_tags(ps->search, out_best_score);
+    ptmr_stop(&ps->perf);
+    return hyptags_list;
+}
+
 int32
 ps_get_prob(ps_decoder_t *ps)
 {

--- a/src/libpocketsphinx/pocketsphinx.c
+++ b/src/libpocketsphinx/pocketsphinx.c
@@ -234,7 +234,7 @@ ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
     	    return -1;
         }
     }
-    
+
     ps->mfclogdir = cmd_ln_str_r(ps->config, "-mfclogdir");
     ps->rawlogdir = cmd_ln_str_r(ps->config, "-rawlogdir");
     ps->senlogdir = cmd_ln_str_r(ps->config, "-senlogdir");
@@ -324,7 +324,7 @@ ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
         fsg_model_free(fsg);
         ps_set_search(ps, PS_DEFAULT_SEARCH);
     }
-    
+
     /* Or load a JSGF grammar */
     if ((path = cmd_ln_str_r(ps->config, "-jsgf"))) {
         if (ps_set_jsgf_file(ps, PS_DEFAULT_SEARCH, path)
@@ -338,7 +338,7 @@ ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
                 return -1;
     }
 
-    if ((path = cmd_ln_str_r(ps->config, "-lm")) && 
+    if ((path = cmd_ln_str_r(ps->config, "-lm")) &&
         !cmd_ln_boolean_r(ps->config, "-allphone")) {
         if (ps_set_lm_file(ps, PS_DEFAULT_SEARCH, path)
             || ps_set_search(ps, PS_DEFAULT_SEARCH))
@@ -356,8 +356,8 @@ ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
         }
 
         for(lmset_it = ngram_model_set_iter(lmset);
-            lmset_it; lmset_it = ngram_model_set_iter_next(lmset_it)) {    
-            ngram_model_t *lm = ngram_model_set_iter_model(lmset_it, &name);            
+            lmset_it; lmset_it = ngram_model_set_iter_next(lmset_it)) {
+            ngram_model_t *lm = ngram_model_set_iter_model(lmset_it, &name);
             E_INFO("adding search %s\n", name);
             if (ps_set_lm(ps, name, lm)) {
                 ngram_model_set_iter_free(lmset_it);
@@ -387,7 +387,7 @@ ps_decoder_t *
 ps_init(cmd_ln_t *config)
 {
     ps_decoder_t *ps;
-    
+
     if (!config) {
 	E_ERROR("No configuration specified");
 	return NULL;
@@ -502,7 +502,7 @@ ps_get_search(ps_decoder_t *ps)
     return name;
 }
 
-int 
+int
 ps_unset_search(ps_decoder_t *ps, const char *name)
 {
     ps_search_t *search = hash_table_delete(ps->searches, name);
@@ -526,13 +526,13 @@ ps_search_iter_next(ps_search_iter_t *itor)
    return (ps_search_iter_t *)hash_table_iter_next((hash_iter_t *)itor);
 }
 
-const char* 
+const char*
 ps_search_iter_val(ps_search_iter_t *itor)
 {
    return (const char*)(((hash_iter_t *)itor)->ent->key);
 }
 
-void 
+void
 ps_search_iter_free(ps_search_iter_t *itor)
 {
     hash_table_iter_free((hash_iter_t *)itor);
@@ -569,7 +569,7 @@ static int
 set_search_internal(ps_decoder_t *ps, ps_search_t *search)
 {
     ps_search_t *old_search;
-    
+
     if (!search)
 	return -1;
 
@@ -651,7 +651,7 @@ ps_set_fsg(ps_decoder_t *ps, const char *name, fsg_model_t *fsg)
     return set_search_internal(ps, search);
 }
 
-int 
+int
 ps_set_jsgf_file(ps_decoder_t *ps, const char *name, const char *path)
 {
   fsg_model_t *fsg;
@@ -690,7 +690,7 @@ ps_set_jsgf_file(ps_decoder_t *ps, const char *name, const char *path)
   return result;
 }
 
-int 
+int
 ps_set_jsgf_string(ps_decoder_t *ps, const char *name, const char *jsgf_string)
 {
   fsg_model_t *fsg;
@@ -865,7 +865,7 @@ ps_lookup_word(ps_decoder_t *ps, const char *word)
     int32 phlen, j;
     char *phones;
     dict_t *dict = ps->dict;
-    
+
     wid = dict_wordid(dict, word);
     if (wid == BAD_S3WID)
 	return NULL;
@@ -936,7 +936,7 @@ ps_start_utt(ps_decoder_t *ps)
 {
     int rv;
     char uttid[16];
-    
+
     if (ps->acmod->state == ACMOD_STARTED || ps->acmod->state == ACMOD_PROCESSING) {
 	E_ERROR("Utterance already started\n");
 	return -1;
@@ -1165,7 +1165,7 @@ ps_end_utt(ps_decoder_t *ps)
         int32 score;
 
         hyp = ps_get_hyp(ps, &score);
-        
+
         if (hyp != NULL) {
     	    E_INFO("%s (%d)\n", hyp, score);
     	    E_INFO_NOFN("%-20s %-5s %-5s %-5s %-10s %-10s %-3s\n",
@@ -1202,13 +1202,28 @@ ps_get_hyp(ps_decoder_t *ps, int32 *out_best_score)
 glist_t
 ps_get_hyp_with_tags(ps_decoder_t *ps, int32 *out_best_score)
 {
-    glist_t hyptags_list;
-
     ptmr_start(&ps->perf);
-    hyptags_list = ps_search_hyp_with_tags(ps->search, out_best_score);
+    glist_t hyptags_list = ps_search_hyp_with_tags(ps->search, out_best_score);
     ptmr_stop(&ps->perf);
     return hyptags_list;
 }
+
+glist_t
+ps_get_word_and_tags(glist_t hyptags_list, char *word)
+{
+    if(!hyptags_list)
+        return NULL;
+
+    ps_hyptags_t *r = (ps_hyptags_t *)gnode_ptr(hyptags_list);
+    if(!r){
+        E_ERROR("glist_t data NULL");
+        return NULL;
+    }
+
+    strncpy(word, r->word, strlen(r->word)+1);
+    return r->tags;
+}
+
 
 int32
 ps_get_prob(ps_decoder_t *ps)
@@ -1374,7 +1389,7 @@ ps_get_all_time(ps_decoder_t *ps, double *out_nspeech,
     *out_nwall = ps->perf.t_tot_elapsed;
 }
 
-uint8 
+uint8
 ps_get_in_speech(ps_decoder_t *ps)
 {
     return fe_get_vad_state(ps->acmod->fe);
@@ -1450,7 +1465,7 @@ ps_search_base_reinit(ps_search_t *search, dict_t *dict,
 }
 
 void
-ps_set_rawdata_size(ps_decoder_t *ps, int32 size) 
+ps_set_rawdata_size(ps_decoder_t *ps, int32 size)
 {
     acmod_set_rawdata_size(ps->acmod, size);
 }

--- a/src/libpocketsphinx/pocketsphinx_internal.h
+++ b/src/libpocketsphinx/pocketsphinx_internal.h
@@ -76,10 +76,10 @@ typedef struct ps_search_s ps_search_t;
 #define PS_SEARCH_TYPE_STATE_ALIGN  "state_align"
 #define PS_SEARCH_TYPE_PHONE_LOOP  "phone_loop"
 
-struct ps_hyptags_s {
+typedef struct ps_hyptags_s{
     char const *word;
     glist_t tags;
-};
+}ps_hyptags_t;
 
 
 /**

--- a/src/libpocketsphinx/pocketsphinx_internal.h
+++ b/src/libpocketsphinx/pocketsphinx_internal.h
@@ -76,6 +76,12 @@ typedef struct ps_search_s ps_search_t;
 #define PS_SEARCH_TYPE_STATE_ALIGN  "state_align"
 #define PS_SEARCH_TYPE_PHONE_LOOP  "phone_loop"
 
+struct ps_hyptags_s {
+    char const *word;
+    glist_t tags;
+};
+
+
 /**
  * V-table for search algorithm.
  */
@@ -88,6 +94,7 @@ typedef struct ps_searchfuncs_s {
 
     ps_lattice_t *(*lattice)(ps_search_t *search);
     char const *(*hyp)(ps_search_t *search, int32 *out_score);
+    glist_t (*hyptags_list)(ps_search_t *search, int32 *out_score);
     int32 (*prob)(ps_search_t *search);
     ps_seg_t *(*seg_iter)(ps_search_t *search);
 } ps_searchfuncs_t;
@@ -107,6 +114,7 @@ struct ps_search_s {
     dict_t *dict;        /**< Pronunciation dictionary. */
     dict2pid_t *d2p;       /**< Dictionary to senone mappings. */
     char *hyp_str;         /**< Current hypothesis string. */
+    glist_t hyptags_list;   /**< glist containing word-tags pairs. */
     ps_lattice_t *dag;	   /**< Current hypothesis word graph. */
     ps_latlink_t *last_link; /**< Final link in best path. */
     int32 post;            /**< Utterance posterior probability. */
@@ -139,6 +147,7 @@ struct ps_search_s {
 #define ps_search_free(s) (*(ps_search_base(s)->vt->free))(s)
 #define ps_search_lattice(s) (*(ps_search_base(s)->vt->lattice))(s)
 #define ps_search_hyp(s,sc) (*(ps_search_base(s)->vt->hyp))(s,sc)
+#define ps_search_hyp_with_tags(s,sc) (*(ps_search_base(s)->vt->hyptags_list))(s,sc)
 #define ps_search_prob(s) (*(ps_search_base(s)->vt->prob))(s)
 #define ps_search_seg_iter(s) (*(ps_search_base(s)->vt->seg_iter))(s)
 

--- a/src/libpocketsphinx/state_align_search.c
+++ b/src/libpocketsphinx/state_align_search.c
@@ -276,6 +276,7 @@ static ps_searchfuncs_t state_align_search_funcs = {
     /* free: */   state_align_search_free,
     /* lattice: */  NULL,
     /* hyp: */      NULL,
+    /* hyptags_list: */ NULL,
     /* prob: */     NULL,
     /* seg_iter: */ NULL,
 };


### PR DESCRIPTION
Together with the pull request on sphinxbase, with this update it would be possible to extract tags from jsgf grammars. 
Two functions on pocketsphinx.h/c were added, one to get the result not just as a simple const char* hyp, but as a complex glist_t (ps_get_hyp_with_tags), which would then be accessed through the other function on pocketsphinx (ps_get_word_and_tags).