### PR TITLE
Makefile for Java SWIG now also works on MacOS

### DIFF
--- a/swig/java/Makefile
+++ b/swig/java/Makefile
@@ -1,7 +1,11 @@
 CFLAGS := -g -Wall -DPIC -fPIC
-CPPFLAGS := -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -Wno-unused-function `pkg-config --cflags sphinxbase pocketsphinx`
+CPPFLAGS := -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin -I$(JAVA_HOME)/include/linux -Wno-unused-function `pkg-config --cflags sphinxbase pocketsphinx`
 
 all: libpocketsphinx_jni.so
+
+libpocketsphinx_jni.dylib: pocketsphinx_wrap.o sphinxbase_wrap.o
+	$(CC) -dynamiclib -o $@ pocketsphinx_wrap.o sphinxbase_wrap.o `pkg-config --libs sphinxbase pocketsphinx`
+
 
 libpocketsphinx_jni.so: pocketsphinx_wrap.o sphinxbase_wrap.o
 	$(CC) -shared -o $@ pocketsphinx_wrap.o sphinxbase_wrap.o `pkg-config --libs sphinxbase pocketsphinx`


### PR DESCRIPTION
The old Makefile for Java SWIG only worked on Linux. I have edited the Makefile so it can now produce libpocketsphinx_jni.dylib, which is what Java on MacOS is looking for.