### PR TITLE
change javascript README for local pocketsphinx instalation

### DIFF
--- a/swig/javascript/README
+++ b/swig/javascript/README
@@ -6,8 +6,9 @@ To install it type
 
    npm install -g pocketsphinx
 
-then
-
+then cd to test.js file directory
+   
+   npm install pocketsphinx
    node test.js
 
 Requirements include latest pocketsphinx, sphinxbase and swig 3.0


### PR DESCRIPTION
It need local installation of pocketsphinx to run "node test.js"