### PR TITLE
Fix memory leak in allphone_search.c

### DIFF
--- a/src/libpocketsphinx/allphone_search.c
+++ b/src/libpocketsphinx/allphone_search.c
@@ -648,6 +648,7 @@ allphone_search_free(ps_search_t * search)
 
     ps_search_base_free(search);
 
+    allphone_clear_segments(allphs);
     hmm_context_free(allphs->hmmctx);
     phmm_free(allphs);
     if (allphs->lm)


### PR DESCRIPTION
Running allphone_backtrace multiple times clears previously allocated segments, but no one ever clears the most recently allocated ones, creating a memory leak which Valgrind attributes to the most recent time allphone_backtrace was run. allphone_search_free seems like the obvious place to do clean it up.