### PR TITLE
Forward declare allphone_clear_segments in allphone_search.c

### DIFF
--- a/src/libpocketsphinx/allphone_search.c
+++ b/src/libpocketsphinx/allphone_search.c
@@ -62,6 +62,8 @@ allphone_search_prob(ps_search_t * search)
 
 static void
 allphone_backtrace(allphone_search_t * allphs, int32 f, int32 *out_score);
+static void
+allphone_clear_segments(allphone_search_t * allphs);
 
 static void
 allphone_search_seg_free(ps_seg_t * seg)


### PR DESCRIPTION
My previous commit broke compilation because the declaration order of the static functions is off (very sorry about that). Rather than moving functions around, it seemed more natural to put this forward declaration in in the same place as the existing one for allphone_backtrace.

Like I should have done last time, I've tested this and it compiles and seems to run correctly (passes the unit tests, doesn't leak).

Edit to add: this resolves #139.