### PR TITLE
Python3 fix: use absolute import

### DIFF
--- a/swig/python/__init__.py
+++ b/swig/python/__init__.py
@@ -34,4 +34,4 @@
 # ====================================================================
 
 
-from pocketsphinx import *
+from .pocketsphinx import *


### PR DESCRIPTION
@nshmyrev this fix is needed for python3,
 see https://www.python.org/dev/peps/pep-0404/#imports