### PR TITLE
Improve linking for internal headers

### DIFF
--- a/src/libpocketsphinx/acmod.h
+++ b/src/libpocketsphinx/acmod.h
@@ -61,6 +61,13 @@
 #include "tmat.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * States in utterance processing.
  */
@@ -462,5 +469,9 @@ void acmod_set_rawdata_size(acmod_t *acmod, int32 size);
  * Retrieves the raw data collected during utterance decoding
  */
 void acmod_get_rawdata(acmod_t *acmod, int16 **buffer, int32 *size);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __ACMOD_H__ */

--- a/src/libpocketsphinx/allphone_search.h
+++ b/src/libpocketsphinx/allphone_search.h
@@ -52,6 +52,13 @@
 #include "blkarray_list.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Models a single unique <senone-sequence, tmat> pair.
  * Can represent several different triphones, but all with the same parent basephone.
@@ -175,5 +182,9 @@ int allphone_search_finish(ps_search_t * search);
  * Get hypothesis string from the allphone search.
  */
 char const *allphone_search_hyp(ps_search_t * search, int32 * out_score);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif                          /* __ALLPHONE_SEARCH_H__ */

--- a/src/libpocketsphinx/bin_mdef.h
+++ b/src/libpocketsphinx/bin_mdef.h
@@ -47,7 +47,10 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
+#if 0
+}
+#endif
 
 /* SphinxBase headers. */
 #include <sphinxbase/mmio.h>
@@ -230,7 +233,7 @@ int bin_mdef_phone_str(bin_mdef_t *m,	/**< In: Model structure being queried */
 		       char *buf);	/**< Out: On return, buf has the string */
 
 #ifdef __cplusplus
-}; /* extern "C" */
-#endif /* __cplusplus */
+} /* extern "C" */
+#endif
 
 #endif /* __BIN_MDEF_H__ */

--- a/src/libpocketsphinx/blkarray_list.h
+++ b/src/libpocketsphinx/blkarray_list.h
@@ -68,6 +68,12 @@
 
 #include <sphinxbase/prim_type.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
 
 /*
  * For maintaining a (conceptual) "list" of pointers to arbitrary data.
@@ -135,5 +141,9 @@ void blkarray_list_reset (blkarray_list_t *);
 
 /* Gets n-th element of the array list */
 void * blkarray_list_get(blkarray_list_t *, int32 n);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/src/libpocketsphinx/dict.h
+++ b/src/libpocketsphinx/dict.h
@@ -55,6 +55,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /** 
     \struct dictword_t
@@ -204,7 +207,7 @@ void dict_report(dict_t *d /**< A dictionary structure */
     );
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif

--- a/src/libpocketsphinx/dict.h
+++ b/src/libpocketsphinx/dict.h
@@ -60,7 +60,7 @@ extern "C" {
     \struct dictword_t
     \brief a structure for one dictionary word. 
 */
-typedef struct {
+typedef struct dictword_s {
     char *word;		/**< Ascii word string */
     s3cipid_t *ciphone;	/**< Pronunciation */
     int32 pronlen;	/**< Pronunciation length */
@@ -73,7 +73,7 @@ typedef struct {
     \brief a structure for a dictionary. 
 */
 
-typedef struct {
+typedef struct dict_s {
     int refcnt;
     bin_mdef_t *mdef;	/**< Model definition used for phone IDs; NULL if none used */
     dictword_t *word;	/**< Array of entries in dictionary */

--- a/src/libpocketsphinx/dict2pid.h
+++ b/src/libpocketsphinx/dict2pid.h
@@ -64,6 +64,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /**
  * \struct xwdssid_t
@@ -173,8 +176,7 @@ s3cipid_t* dict2pid_get_rcmap(dict2pid_t *d2p,  /**< In: a dict2pid */
     );
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
-
 
 #endif

--- a/src/libpocketsphinx/dict2pid.h
+++ b/src/libpocketsphinx/dict2pid.h
@@ -70,7 +70,7 @@ extern "C" {
  * \brief cross word triphone model structure 
  */
 
-typedef struct {
+typedef struct xwdssid_s {
     s3ssid_t  *ssid;	/**< Senone Sequence ID list for all context ciphones */
     s3cipid_t *cimap;	/**< Index into ssid[] above for each ci phone */
     int32     n_ssid;	/**< #Unique ssid in above, compressed ssid list */
@@ -81,7 +81,7 @@ typedef struct {
    \brief Building composite triphone (as well as word internal triphones) with the dictionary. 
 */
 
-typedef struct {
+typedef struct dict2pid_s {
     int refcount;
 
     bin_mdef_t *mdef;           /**< Model definition, used to generate

--- a/src/libpocketsphinx/fsg_history.h
+++ b/src/libpocketsphinx/fsg_history.h
@@ -84,6 +84,13 @@
 #include "fsg_lextree.h"
 #include "dict.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /*
  * The Viterbi history structure.  This is a tree, with the root at the
  * FSG start state, at frame 0, with a null predecessor.
@@ -212,4 +219,8 @@ void fsg_history_free (fsg_history_t *h);
 /* Print the entire history */
 void fsg_history_print(fsg_history_t *h, dict_t *dict);
 				     
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #endif

--- a/src/libpocketsphinx/fsg_lextree.h
+++ b/src/libpocketsphinx/fsg_lextree.h
@@ -48,6 +48,13 @@
 #include "dict.h"
 #include "dict2pid.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /*
  * Compile-time constant determining the size of the
  * bitvector fsg_pnode_t.fsg_pnode_ctxt_t.bv.  (See below.)
@@ -251,5 +258,9 @@ void fsg_pnode_add_all_ctxt(fsg_pnode_ctxt_t *ctxt);
  *  Generic variant for arbitrary size
  */
 uint32 fsg_pnode_ctxt_sub_generic(fsg_pnode_ctxt_t *src, fsg_pnode_ctxt_t *sub);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/src/libpocketsphinx/fsg_lextree.h
+++ b/src/libpocketsphinx/fsg_lextree.h
@@ -57,7 +57,7 @@
  */
 #define FSG_PNODE_CTXT_BVSZ	4
 
-typedef struct {
+typedef struct fsg_pnode_ctxt_s {
     uint32 bv[FSG_PNODE_CTXT_BVSZ];
 } fsg_pnode_ctxt_t;
 

--- a/src/libpocketsphinx/fsg_search_internal.h
+++ b/src/libpocketsphinx/fsg_search_internal.h
@@ -52,6 +52,13 @@
 #include "fsg_history.h"
 #include "fsg_lextree.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Segmentation "iterator" for FSG history.
  */
@@ -149,5 +156,9 @@ int fsg_search_finish(ps_search_t *search);
  * Get hypothesis string from the FSG search.
  */
 char const *fsg_search_hyp(ps_search_t *search, int32 *out_score);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/src/libpocketsphinx/hmm.h
+++ b/src/libpocketsphinx/hmm.h
@@ -55,6 +55,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /** 
  * Type for frame index values. Used in HMM indexes and 
@@ -300,7 +303,7 @@ void hmm_dump(hmm_t *h,  /**< In/Out: HMM being updated */
 
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* __HMM_H__ */

--- a/src/libpocketsphinx/kws_detections.h
+++ b/src/libpocketsphinx/kws_detections.h
@@ -46,6 +46,13 @@
 #include "pocketsphinx_internal.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 typedef struct kws_detection_s {
     const char* keyphrase;
     frame_idx_t sf;
@@ -72,5 +79,9 @@ void kws_detections_add(kws_detections_t *detections, const char* keyphrase, int
  * Compose hypothesis.
  */
 char* kws_detections_hyp_str(kws_detections_t *detections, int frame, int delay);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __KWS_DETECTIONS_H__ */

--- a/src/libpocketsphinx/kws_search.h
+++ b/src/libpocketsphinx/kws_search.h
@@ -48,6 +48,13 @@
 #include "kws_detections.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Segmentation "iterator" for KWS history.
  */
@@ -138,5 +145,9 @@ char const *kws_search_hyp(ps_search_t * search, int32 * out_score);
  * Get active keyphrases
  */
 char* kws_search_get_keyphrases(ps_search_t * search);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif                          /* __KWS_SEARCH_H__ */

--- a/src/libpocketsphinx/mdef.h
+++ b/src/libpocketsphinx/mdef.h
@@ -84,7 +84,7 @@ typedef enum {
    \struct ciphone_t
    \brief CI phone information 
 */
-typedef struct {
+typedef struct ciphone_s {
     char *name;                 /**< The name of the CI phone */
     int32 filler;		/**< Whether a filler phone; if so, can be substituted by
 				   silence phone in left or right context position */
@@ -94,7 +94,7 @@ typedef struct {
  * \struct phone_t
  * \brief Triphone information, including base phones as a subset.  For the latter, lc, rc and wpos are non-existent.
  */
-typedef struct {
+typedef struct phone_s {
     int32 ssid;			/**< State sequence (or senone sequence) ID, considering the
 				   n_emit_state senone-ids are a unit.  The senone sequences
 				   themselves are in a separate table */
@@ -132,7 +132,7 @@ typedef struct ph_lc_s {
    \struct mdef_t
    \brief strcture for storing the model definition. 
 */
-typedef struct {
+typedef struct mdef_s {
     int32 n_ciphone;		/**< number basephones actually present */
     int32 n_phone;		/**< number basephones + number triphones actually present */
     int32 n_emit_state;		/**< number emitting states per phone */

--- a/src/libpocketsphinx/mdef.h
+++ b/src/libpocketsphinx/mdef.h
@@ -60,6 +60,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /** \file mdef.h
  * \brief Model definition 
@@ -265,7 +268,7 @@ void mdef_free (mdef_t *mdef /**< In : The model definition*/
 
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif

--- a/src/libpocketsphinx/ms_gauden.h
+++ b/src/libpocketsphinx/ms_gauden.h
@@ -63,6 +63,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /**
  * \struct gauden_dist_t
@@ -144,7 +147,7 @@ void gauden_dump_ind (const gauden_t *g,  /**< In: Gaussian distribution g*/
     );
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* GAUDEN_H */ 

--- a/src/libpocketsphinx/ms_gauden.h
+++ b/src/libpocketsphinx/ms_gauden.h
@@ -68,7 +68,7 @@ extern "C" {
  * \struct gauden_dist_t
  * \brief Structure to store distance (density) values for a given input observation wrt density values in some given codebook.
  */
-typedef struct {
+typedef struct gauden_dist_s {
     int32 id;		/**< Index of codeword (gaussian density) */
     mfcc_t dist;		/**< Density value for input observation wrt above codeword;
                            NOTE: result in logs3 domain, but var_t used for speed */
@@ -79,7 +79,7 @@ typedef struct {
  * \struct gauden_t
  * \brief Multivariate gaussian mixture density parameters
  */
-typedef struct {
+typedef struct gauden_s {
     mfcc_t ****mean;	/**< mean[codebook][feature][codeword] vector */
     mfcc_t ****var;	/**< like mean; diagonal covariance vector only */
     mfcc_t ***det;	/**< log(determinant) for each variance vector;

--- a/src/libpocketsphinx/ms_mgau.h
+++ b/src/libpocketsphinx/ms_mgau.h
@@ -107,6 +107,13 @@
 #include "ms_gauden.h"
 #include "ms_senone.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /** \struct ms_mgau_t
     \brief Multi-stream mixture gaussian. It is not necessary to be continr
 */
@@ -139,5 +146,8 @@ int32 ms_cont_mgau_frame_eval(ps_mgau_t * msg,
 int32 ms_mgau_mllr_transform(ps_mgau_t *s,
                              ps_mllr_t *mllr);
 
-#endif /* _LIBFBS_MS_CONT_MGAU_H_*/
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
+#endif /* _LIBFBS_MS_CONT_MGAU_H_*/

--- a/src/libpocketsphinx/ms_mgau.h
+++ b/src/libpocketsphinx/ms_mgau.h
@@ -111,7 +111,7 @@
     \brief Multi-stream mixture gaussian. It is not necessary to be continr
 */
 
-typedef struct {
+typedef struct ms_mgau_model_s {
     ps_mgau_t base;
     gauden_t* g;   /**< The codebook */
     senone_t* s;   /**< The senone */

--- a/src/libpocketsphinx/ms_senone.h
+++ b/src/libpocketsphinx/ms_senone.h
@@ -63,6 +63,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 typedef uint8 senprob_t;	/**< Senone logs3-probs, truncated to 8 bits */
 
@@ -125,7 +128,7 @@ int32 senone_eval (senone_t *s, int id,		/**< In: senone for which score desired
     );
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif

--- a/src/libpocketsphinx/ms_senone.h
+++ b/src/libpocketsphinx/ms_senone.h
@@ -73,7 +73,7 @@ typedef uint8 senprob_t;	/**< Senone logs3-probs, truncated to 8 bits */
  * 8-bit senone PDF structure.  Senone pdf values are normalized, floored, converted to
  * logs3 domain, and finally truncated to 8 bits precision to conserve memory space.
  */
-typedef struct {
+typedef struct senone_s {
     senprob_t ***pdf;		/**< gaussian density mixture weights, organized two possible
                                    ways depending on n_gauden:
                                    if (n_gauden > 1): pdf[sen][feat][codeword].  Not an

--- a/src/libpocketsphinx/ngram_search.h
+++ b/src/libpocketsphinx/ngram_search.h
@@ -53,6 +53,13 @@
 #include "pocketsphinx_internal.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Lexical tree node data type.
  *
@@ -430,5 +437,9 @@ int32 ngram_search_exit_score(ngram_search_t *ngs, bptbl_t *pbe, int rcphone);
  * Sets the language model to use if nothing was passed in configuration
  */
 void ngram_search_set_lm(ngram_model_t *lm);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __NGRAM_SEARCH_H__ */

--- a/src/libpocketsphinx/ngram_search.h
+++ b/src/libpocketsphinx/ngram_search.h
@@ -148,14 +148,14 @@ typedef struct lastphn_cand_s {
  * just the first time and cache it for future occurrences.  Structure for such
  * a cache.
  */
-typedef struct {
+typedef struct last_ltrans_s {
     int32 sf;                   /* Start frame */
     int32 dscr;                 /* Delta-score upon entering last phone */
     int32 bp;                   /* Best BP */
 } last_ltrans_t;
 
 #define CAND_SF_ALLOCSIZE	32
-typedef struct {
+typedef struct cand_sf_s {
     int32 bp_ef;
     int32 cand;
 } cand_sf_t;

--- a/src/libpocketsphinx/ngram_search_fwdflat.h
+++ b/src/libpocketsphinx/ngram_search_fwdflat.h
@@ -47,6 +47,13 @@
 /* Local headers. */
 #include "ngram_search.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Initialize N-Gram search for fwdflat decoding.
  */
@@ -77,5 +84,8 @@ int ngram_fwdflat_search(ngram_search_t *ngs, int frame_idx);
  */
 void ngram_fwdflat_finish(ngram_search_t *ngs);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __NGRAM_SEARCH_FWDFLAT_H__ */

--- a/src/libpocketsphinx/ngram_search_fwdtree.h
+++ b/src/libpocketsphinx/ngram_search_fwdtree.h
@@ -47,6 +47,13 @@
 /* Local headers. */
 #include "ngram_search.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Initialize N-Gram search for fwdtree decoding.
  */
@@ -79,5 +86,8 @@ int ngram_fwdtree_search(ngram_search_t *ngs, int frame_idx);
  */
 void ngram_fwdtree_finish(ngram_search_t *ngs);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __NGRAM_SEARCH_FWDTREE_H__ */

--- a/src/libpocketsphinx/phone_loop_search.h
+++ b/src/libpocketsphinx/phone_loop_search.h
@@ -57,6 +57,13 @@
 #include "pocketsphinx_internal.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Renormalization event.
  */
@@ -98,5 +105,9 @@ ps_search_t *phone_loop_search_init(cmd_ln_t *config,
  */
 #define phone_loop_search_score(pls,ci) \
     ((pls == NULL) ? 0 : (pls->penalties[ci]))
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __PHONE_LOOP_SEARCH_H__ */

--- a/src/libpocketsphinx/pocketsphinx_internal.h
+++ b/src/libpocketsphinx/pocketsphinx_internal.h
@@ -58,6 +58,13 @@
 #include "dict.h"
 #include "dict2pid.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Search algorithm structure.
  */
@@ -230,5 +237,9 @@ struct ps_decoder_s {
 struct ps_search_iter_s {
     hash_iter_t itor;
 };
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __POCKETSPHINX_INTERNAL_H__ */

--- a/src/libpocketsphinx/ps_alignment.h
+++ b/src/libpocketsphinx/ps_alignment.h
@@ -51,6 +51,13 @@
 #include "dict2pid.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 #define PS_ALIGNMENT_NONE ((uint16)0xffff)
 
 struct ps_alignment_entry_s {
@@ -204,5 +211,9 @@ ps_alignment_iter_t *ps_alignment_iter_down(ps_alignment_iter_t *itor);
  * Release an iterator before completing all iterations.
  */
 int ps_alignment_iter_free(ps_alignment_iter_t *itor);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __PS_ALIGNMENT_H__ */

--- a/src/libpocketsphinx/ps_lattice_internal.h
+++ b/src/libpocketsphinx/ps_lattice_internal.h
@@ -42,6 +42,13 @@
 #ifndef __PS_LATTICE_INTERNAL_H__
 #define __PS_LATTICE_INTERNAL_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 /**
  * Linked list of DAG link pointers.
  *
@@ -278,5 +285,8 @@ char const *ps_astar_hyp(ps_astar_t *nbest, ps_latpath_t *path);
  */
 ps_seg_t *ps_astar_seg_iter(ps_astar_t *astar, ps_latpath_t *path, float32 lwf);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __PS_LATTICE_INTERNAL_H__ */

--- a/src/libpocketsphinx/ps_lattice_internal.h
+++ b/src/libpocketsphinx/ps_lattice_internal.h
@@ -42,6 +42,9 @@
 #ifndef __PS_LATTICE_INTERNAL_H__
 #define __PS_LATTICE_INTERNAL_H__
 
+/* Local headers. */
+#include "pocketsphinx_internal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/libpocketsphinx/ptm_mgau.h
+++ b/src/libpocketsphinx/ptm_mgau.h
@@ -53,6 +53,13 @@
 #include "bin_mdef.h"
 #include "ms_gauden.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 typedef struct ptm_mgau_s ptm_mgau_t;
 
 typedef struct ptm_topn_s {
@@ -99,5 +106,8 @@ int ptm_mgau_frame_eval(ps_mgau_t *s,
 int ptm_mgau_mllr_transform(ps_mgau_t *s,
                             ps_mllr_t *mllr);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /*  __PTM_MGAU_H__ */

--- a/src/libpocketsphinx/s2_semi_mgau.h
+++ b/src/libpocketsphinx/s2_semi_mgau.h
@@ -53,6 +53,13 @@
 #include "bin_mdef.h"
 #include "ms_gauden.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 typedef struct vqFeature_s vqFeature_t;
 
 typedef struct s2_semi_mgau_s s2_semi_mgau_t;
@@ -94,5 +101,8 @@ int s2_semi_mgau_frame_eval(ps_mgau_t *s,
 int s2_semi_mgau_mllr_transform(ps_mgau_t *s,
                                 ps_mllr_t *mllr);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /*  __S2_SEMI_MGAU_H__ */

--- a/src/libpocketsphinx/s3types.h
+++ b/src/libpocketsphinx/s3types.h
@@ -52,6 +52,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /**
  * Size definitions for more semantially meaningful units.
@@ -93,7 +96,7 @@ typedef int32		s3wid_t;	/** Dictionary word id */
 #define MAX_S3WID	((int32)0x7ffffffe)
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif

--- a/src/libpocketsphinx/state_align_search.h
+++ b/src/libpocketsphinx/state_align_search.h
@@ -50,6 +50,12 @@
 #include "ps_alignment.h"
 #include "hmm.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
 
 /**
  * History structure
@@ -83,5 +89,9 @@ ps_search_t *state_align_search_init(const char *name,
 				     cmd_ln_t *config,
                                      acmod_t *acmod,
                                      ps_alignment_t *al);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __STATE_ALIGN_SEARCH_H__ */

--- a/src/libpocketsphinx/tied_mgau_common.h
+++ b/src/libpocketsphinx/tied_mgau_common.h
@@ -46,6 +46,13 @@
 #include <sphinxbase/logmath.h>
 #include <sphinxbase/fixpoint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 #define MGAU_MIXW_VERSION	"1.0"   /* Sphinx-3 file format version for mixw */
 #define MGAU_PARAM_VERSION	"1.0"   /* Sphinx-3 file format version for mean/var */
 #define NONE		-1
@@ -117,5 +124,9 @@ fast_logmath_add(logmath_t *lmath, int mlx, int mly)
 
     return r - (((uint8 *)t->table)[d]);
 }
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __TIED_MGAU_COMMON_H__ */

--- a/src/libpocketsphinx/tmat.h
+++ b/src/libpocketsphinx/tmat.h
@@ -46,6 +46,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#if 0
+}
+#endif
 
 /**
  * \struct tmat_t
@@ -92,7 +95,7 @@ void tmat_report(tmat_t *t /**< In: transition matrix*/
     );
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif

--- a/src/libpocketsphinx/tmat.h
+++ b/src/libpocketsphinx/tmat.h
@@ -52,7 +52,7 @@ extern "C" {
  * \brief Transition matrix data structure.  All phone HMMs are assumed to have the same
  * topology.
  */
-typedef struct {
+typedef struct tmat_s {
     uint8 ***tp;	/**< The transition matrices; kept in the same scale as acoustic scores;
 			   tp[tmatid][from-state][to-state] */
     int16 n_tmat;	/**< Number matrices */

--- a/src/libpocketsphinx/vector.h
+++ b/src/libpocketsphinx/vector.h
@@ -55,6 +55,13 @@
 /* SphinxBase headers. */
 #include <sphinxbase/prim_type.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if 0
+}
+#endif
+
 typedef float32 *vector_t;
 
 /*
@@ -85,5 +92,9 @@ void vector_print(FILE *fp, vector_t v, int32 dim);
 /* Return TRUE iff given vector is all 0.0 */
 int32 vector_is_zero (float32 *vec,	/* In: Vector to be checked */
 		      int32 len);	/* In: Length of above vector */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* VECTOR_H */ 


### PR DESCRIPTION
This pull request makes the following changes:

- Most struct declarations were of the form `typedef struct name_s { /* data fields */ } name_t`, but some were typedef'd anonymously (without `name_s`): `typedef struct { /* data fields */ } name_t`. This made it impossible to forward declare them. I have added the `name_s` part to all headers which omitted it.

- A seemingly random selection of the internal headers had the `extern "C"` required for linking with C++, but many did not have it; also, most of the internal headers containing `extern "C"` used a style that differed from the style used in the public API headers, and some had extraneous semicolons which caused compiler warnings. I have added the directive to all internal headers and unified the style with that of the public API headers.

- `ps_lattice_internal.h` required `pocketsphinx_internal.h` but did not include it, so it would not work unless `pocketsphinx_internal.h` was included first. I have added the missing `#include` directive.