### PR TITLE
Make use of stdbool.h when generating Python interface

### DIFF
--- a/swig/pocketsphinx.i
+++ b/swig/pocketsphinx.i
@@ -96,9 +96,7 @@ typedef ngram_model_t NGramModelSet;
 %begin %{
 
 #ifndef __cplusplus
-typedef int bool;
-#define true 1
-#define false 0
+#include <stdbool.h>
 #endif
 
 #include <pocketsphinx.h>


### PR DESCRIPTION
It seems building pocketsphinx does not work with Python's 3.11
series. Trying to compile fails with this error:

In file included from /usr/include/python3.11/cpython/pystate.h:5,
                 from /usr/include/python3.11/pystate.h:135,
                 from /usr/include/python3.11/Python.h:76,
                 from pocketsphinx_wrap.c:11:
pocketsphinx_wrap.c:16:13: error: two or more data types in declaration specifiers
   16 | typedef int bool;
      |             ^~~~
pocketsphinx_wrap.c:16:1: warning: useless type name in empty declaration
   16 | typedef int bool;
      | ^~~~~~~

My guess is that one of the Python header files started including
stdbool.h, and thus the type bool conflicts with the name bool in:

typedef int bool;

The offending code is generated using swig.

This commit removes the definition of bool and instead includes
stdbool.h to make use of the system definition.

Signed-off-by: W. Michael Petullo <mike@flyn.org>