### PR TITLE
Fix endianness issues in binary trie LM code

### DIFF
--- a/include/sphinxbase/bitarr.h
+++ b/include/sphinxbase/bitarr.h
@@ -46,9 +46,19 @@
 
 /** 
  * @file bitarr.h
- * @brief An implementation bit array - memory efficient storage for digit int and float data.
+ * @brief An implementation bit array - memory
+ * efficient storage for digit int and float data. (FIXME: NO)
  * 
- * Implementation of basic operations of read/write digits consuming as little space as possible.
+ * Implementation of basic operations of read/write digits consuming
+ * as little space as possible.
+ *
+ * I HAVE QUESTIONS.  Why 25 and 57 bits?  What are the other 7 bits
+ * *doing*?!?  Why didn't you stop to think about architectures with
+ * big-endian byte ordering or strictly aligned memory access when you
+ * wrote this?  Does it really store floats BECAUSE NO IT DOESN'T
+ *
+ * Note that because of the problems noted above data is canonically
+ * stored in little-endian order in memory.
  */
 
 #ifdef __cplusplus

--- a/src/lm/lm_trie.h
+++ b/src/lm/lm_trie.h
@@ -77,7 +77,7 @@ typedef struct longest_s {
 } longest_t;
 
 typedef struct lm_trie_s {
-    uint8 *ngram_mem;
+    uint8 *ngram_mem; /*<< This appears to be a bitarr.h bit array */
     size_t ngram_mem_size;
     unigram_t *unigrams;
     middle_t *middle_begin;

--- a/src/lm/lm_trie_quant.h
+++ b/src/lm/lm_trie_quant.h
@@ -41,6 +41,19 @@
 
 #include "ngrams_raw.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#if defined(DEBUG_ENDIAN) || defined(WORDS_BIGENDIAN)
+/* For some reason nobody ever considered the endianness of
+   this file.  I declare it to be canonically little-endian. */
+#define SWAP_LM_TRIE 1
+#else
+#define SWAP_LM_TRIE 0
+#endif
+
+
 typedef struct lm_trie_quant_s lm_trie_quant_t;
 
 /**

--- a/src/util/bitarr.c
+++ b/src/util/bitarr.c
@@ -69,6 +69,7 @@ static uint8 get_shift(uint8 bit, uint8 length)
  */
 static uint64 read_off(bitarr_address_t address)
 {
+    /* FIXME: Likely to be needed on not just ARM */
 #if defined(__arm) || defined(__arm__)
     uint64 value64;
     const uint8 *base_off = (const uint8 *)(address.base) + (address.offset >> 3);

--- a/src/util/bitarr.c
+++ b/src/util/bitarr.c
@@ -40,48 +40,20 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
+
+#include "sphinxbase/err.h"
 #include "sphinxbase/bitarr.h"
-
-#define SIGN_BIT (0x80000000)
-
-/**
- * Shift bits depending on byte order in system for 64-bit access.
- * @param bit is an offset last byte
- * @param length - amount of bits for required for digit that is going to be read
- * @return shift forgiven architecture
- */
-static uint8 get_shift64(uint8 bit, uint8 length)
-{
-#ifdef WORDS_BIGENDIAN
-    return 64 - length - bit;
-#else
-    return bit;
-#endif
-}
-
-/**
- * Shift bits depending on byte order in system for 32-bit access.
- * @param bit is an offset last byte
- * @param length - amount of bits for required for digit that is going to be read
- * @return shift forgiven architecture
- */
-static uint8 get_shift32(uint8 bit, uint8 length)
-{
-#ifdef WORDS_BIGENDIAN
-    return 32 - length - bit;
-#else
-    return bit;
-#endif
-}
+#include "sphinxbase/byteorder.h"
 
 uint64 bitarr_read_int57(bitarr_address_t address, uint8 length, uint64 mask)
 {
     uint64 value64;
     const uint8 *base_off = (const uint8 *)(address.base) + (address.offset >> 3);
     memcpy(&value64, base_off, sizeof(value64));
-    return (value64 >> get_shift64(address.offset & 7, length)) & mask;
+    SWAP_LE_64(&value64);
+    return (value64 >> (address.offset & 7)) & mask;
 }
 
 void bitarr_write_int57(bitarr_address_t address, uint8 length, uint64 value) 
@@ -89,7 +61,9 @@ void bitarr_write_int57(bitarr_address_t address, uint8 length, uint64 value)
     uint64 value64;
     uint8 *base_off = (uint8 *)(address.base) + (address.offset >> 3);
     memcpy(&value64, base_off, sizeof(value64));
-    value64 |= (value << get_shift64(address.offset & 7, length));
+    SWAP_LE_64(&value64);
+    value64 |= (value << (address.offset & 7));
+    SWAP_LE_64(&value64);
     memcpy(base_off, &value64, sizeof(value64));
 }
 
@@ -98,7 +72,8 @@ uint32 bitarr_read_int25(bitarr_address_t address, uint8 length, uint32 mask)
     uint32 value32;
     const uint8 *base_off = (const uint8*)(address.base) + (address.offset >> 3);
     memcpy(&value32, base_off, sizeof(value32));
-    return (value32 >> get_shift32(address.offset & 7, length)) & mask;
+    SWAP_LE_32(&value32);
+    return (value32 >> (address.offset & 7)) & mask;
 }
 
 void bitarr_write_int25(bitarr_address_t address, uint8 length, uint32 value)
@@ -106,7 +81,9 @@ void bitarr_write_int25(bitarr_address_t address, uint8 length, uint32 value)
     uint32 value32;
     uint8 *base_off = (uint8 *)(address.base) + (address.offset >> 3);
     memcpy(&value32, base_off, sizeof(value32));
-    value32 |= (value << get_shift32(address.offset & 7, length));
+    SWAP_LE_32(&value32);
+    value32 |= (value << (address.offset & 7));
+    SWAP_LE_32(&value32);
     memcpy(base_off, &value32, sizeof(value32));
 }
 

--- a/test/unit/test_ngram/test_lm_read.c
+++ b/test/unit/test_ngram/test_lm_read.c
@@ -1,6 +1,7 @@
 #include <sphinxbase/ngram_model.h>
 #include <sphinxbase/logmath.h>
 #include <sphinxbase/strfuncs.h>
+#include <sphinxbase/err.h>
 
 #include "test_macros.h"
 
@@ -47,6 +48,8 @@ main(int argc, char *argv[])
 {
 	logmath_t *lmath;
 	ngram_model_t *model;
+
+	err_set_loglevel(ERR_INFO);
 
 	/* Initialize a logmath object to pass to ngram_read */
 	lmath = logmath_init(1.0001, 0, 0);

--- a/test/unit/test_ngram/test_lm_write.c
+++ b/test/unit/test_ngram/test_lm_write.c
@@ -29,6 +29,7 @@ test_lm_vals(ngram_model_t *model)
 				  NGRAM_INVALID_WID, &n_used), -64208);
 	TEST_EQUAL(n_used, 1);
 	/* Test bigrams. */
+	E_INFO("%d\n", ngram_score(model, "huggins", "david", NULL));
 	TEST_EQUAL_LOG(ngram_score(model, "huggins", "david", NULL), -831);
 	/* Test trigrams. */
 	TEST_EQUAL_LOG(ngram_score(model, "daines", "huggins", "david", NULL), -9450);
@@ -41,12 +42,16 @@ main(int argc, char *argv[])
 	logmath_t *lmath;
 	ngram_model_t *model;
 
+	err_set_loglevel(ERR_INFO);
+
 	/* Initialize a logmath object to pass to ngram_read */
 	lmath = logmath_init(1.0001, 0, 0);
 
 	E_INFO("Converting ARPA to BIN\n");
 	model = ngram_model_read(NULL, LMDIR "/100.lm.bz2", NGRAM_ARPA, lmath);
+	E_INFO("Verifying ARPA\n");
 	test_lm_vals(model);
+	E_INFO("Writing BIN\n");
 	TEST_EQUAL(0, ngram_model_write(model, "100.tmp.lm.bin", NGRAM_BIN));
 	ngram_model_free(model);
 

--- a/test/unit/test_ngram/test_lm_write.c
+++ b/test/unit/test_ngram/test_lm_write.c
@@ -12,7 +12,7 @@
 static int
 test_lm_vals(ngram_model_t *model)
 {
-	int32 n_used;
+	int32 n_used, score;
 
 	TEST_ASSERT(model);
 	TEST_EQUAL(ngram_wid(model, "<UNK>"), 0);
@@ -20,19 +20,28 @@ test_lm_vals(ngram_model_t *model)
 	TEST_EQUAL(ngram_wid(model, "absolute"), 13);
 	TEST_EQUAL(strcmp(ngram_word(model, 13), "absolute"), 0);
 	/* Test unigrams. */
-	TEST_EQUAL_LOG(ngram_score(model, "<UNK>", NULL), -75346);
-	TEST_EQUAL_LOG(ngram_bg_score(model, ngram_wid(model, "<UNK>"),
-				  NGRAM_INVALID_WID, &n_used), -75346);
+	score = ngram_score(model, "<UNK>", NULL);
+	E_INFO("%d\n", score);
+	TEST_EQUAL_LOG(score, -75346);
+	score = ngram_bg_score(model, ngram_wid(model, "<UNK>"),
+			       NGRAM_INVALID_WID, &n_used);
+	E_INFO("%d\n", score);
+	TEST_EQUAL_LOG(score, -75346);
 	TEST_EQUAL(n_used, 1);
-	TEST_EQUAL_LOG(ngram_score(model, "sphinxtrain", NULL), -64208);
+	score = ngram_score(model, "sphinxtrain", NULL);
+	E_INFO("%d\n", score);
+	TEST_EQUAL_LOG(score, -64208);
 	TEST_EQUAL_LOG(ngram_bg_score(model, ngram_wid(model, "sphinxtrain"),
 				  NGRAM_INVALID_WID, &n_used), -64208);
 	TEST_EQUAL(n_used, 1);
 	/* Test bigrams. */
-	E_INFO("%d\n", ngram_score(model, "huggins", "david", NULL));
-	TEST_EQUAL_LOG(ngram_score(model, "huggins", "david", NULL), -831);
+	score = ngram_score(model, "huggins", "david", NULL);
+	E_INFO("%d\n", score);
+	TEST_EQUAL_LOG(score, -831);
 	/* Test trigrams. */
-	TEST_EQUAL_LOG(ngram_score(model, "daines", "huggins", "david", NULL), -9450);
+	score = ngram_score(model, "daines", "huggins", "david", NULL);
+	E_INFO("%d\n", score);
+	TEST_EQUAL_LOG(score, -9450);
 	return 0;
 }
 

--- a/test/unit/test_util/test_bitarr.c
+++ b/test/unit/test_util/test_bitarr.c
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
     bitarr_address_t address;
 
     err_set_loglevel(ERR_INFO);
-    //sign bit should be 0x80000000
+    //sign bit should be 0x80000000 (BUT WHY?!?!?)
     TEST_EQUAL((neg1.i ^ pos1.i), 0x80000000);
     memset(mem, 0, sizeof(mem));
     address.base = mem;
@@ -46,12 +46,13 @@ main(int argc, char *argv[])
     for (address.offset = 0; address.offset < 57 * 8; address.offset += 1) {
       uint64 read57;
 
+      memset(mem, 0, sizeof(mem));
       bitarr_write_int57(address, 57, test57);
       read57 = bitarr_read_int57(address, 57, ((1ULL << 57) - 1));
       E_INFO("Testing %llx at %d = %llx\n", test57, address.offset, read57);
       TEST_EQUAL(test57, read57);
-      memset(mem, 0, sizeof(mem));
     }
+    memset(mem, 0, sizeof(mem));
 
     /* Test packed bits */
     for (address.offset = 0; address.offset < 57 * 8; address.offset += 25)
@@ -61,19 +62,36 @@ main(int argc, char *argv[])
     E_INFO("%d\n", mem[2]);
     E_INFO("%d\n", mem[3]);
     for (address.offset = 0; address.offset < 57 * 8; address.offset += 25) {
-      uint64 read25 = bitarr_read_int25(address, 25, ((1UL << 25) - 1));
+      uint32 read25 = bitarr_read_int25(address, 25, ((1UL << 25) - 1));
       E_INFO("Testing %lx at %d = %lx\n", test25, address.offset, read25);
       TEST_EQUAL(test25, read25);
     }
     /* Test arbitrary addresses */
     for (address.offset = 0; address.offset < 57 * 8; address.offset += 1) {
-      uint64 read25;
+      uint32 read25;
 
+      memset(mem, 0, sizeof(mem));
       bitarr_write_int25(address, 25, test25);
       read25 = bitarr_read_int25(address, 25, ((1UL << 25) - 1));
       E_INFO("Testing %lx at %d = %lx\n", test25, address.offset, read25);
       TEST_EQUAL(test25, read25);
-      memset(mem, 0, sizeof(mem));
+    }
+    memset(mem, 0, sizeof(mem));
+
+    /* Test mixing 32 and 64-bit access. */
+    for (address.offset = 0; address.offset < 57 * 8; address.offset += 82) {
+      bitarr_address_t address2 = address;
+      uint64 read25;
+
+      bitarr_write_int25(address, 25, test25);
+      address2.offset += 25;
+      bitarr_write_int57(address2, 57, test57);
+      read25 = bitarr_read_int25(address, 25, ((1UL << 25) - 1));
+      E_INFO("Testing %lx at %d = %lx\n", test25, address.offset, read25);
+      TEST_EQUAL(test25, read25);
+      read25 = bitarr_read_int57(address2, 57, ((1ULL << 57) - 1));
+      E_INFO("Testing %llx at %d = %llx\n", test57, address2.offset, read25);
+      TEST_EQUAL(test57, read25);
     }
     return 0;
 }

--- a/test/unit/test_util/test_bitarr.c
+++ b/test/unit/test_util/test_bitarr.c
@@ -3,6 +3,7 @@
  */
 
 #include <sphinxbase/bitarr.h>
+#include <sphinxbase/err.h>
 #include "test_macros.h"
 
 #include <stdio.h>
@@ -19,18 +20,60 @@ main(int argc, char *argv[])
 {
     float_enc neg1 = { -1.0 }, pos1 = { 1.0 };
     uint64 test57 = 0x123456789abcdefULL;
+    uint32 test25 = 0x1234567;
     char mem[57+8];
     bitarr_address_t address;
+
+    err_set_loglevel(ERR_INFO);
     //sign bit should be 0x80000000
     TEST_EQUAL((neg1.i ^ pos1.i), 0x80000000);
     memset(mem, 0, sizeof(mem));
     address.base = mem;
-    for (address.offset = 0; address.offset < 57 * 8; address.offset += 57) {
+
+    /* Test packed bits */
+    for (address.offset = 0; address.offset < 57 * 8; address.offset += 57)
       bitarr_write_int57(address, 57, test57);
-    }
+    E_INFO("%d\n", mem[0]);
+    E_INFO("%d\n", mem[1]);
+    E_INFO("%d\n", mem[2]);
+    E_INFO("%d\n", mem[3]);
     for (address.offset = 0; address.offset < 57 * 8; address.offset += 57) {
-      TEST_EQUAL(test57, bitarr_read_int57(address, 57, ((1ULL << 57) - 1)));
+      uint64 read57 = bitarr_read_int57(address, 57, ((1ULL << 57) - 1));
+      E_INFO("Testing %llx at %d = %llx\n", test57, address.offset, read57);
+      TEST_EQUAL(test57, read57);
     }
-    // TODO: more checks.
+    /* Test arbitrary addresses */
+    for (address.offset = 0; address.offset < 57 * 8; address.offset += 1) {
+      uint64 read57;
+
+      bitarr_write_int57(address, 57, test57);
+      read57 = bitarr_read_int57(address, 57, ((1ULL << 57) - 1));
+      E_INFO("Testing %llx at %d = %llx\n", test57, address.offset, read57);
+      TEST_EQUAL(test57, read57);
+      memset(mem, 0, sizeof(mem));
+    }
+
+    /* Test packed bits */
+    for (address.offset = 0; address.offset < 57 * 8; address.offset += 25)
+      bitarr_write_int25(address, 25, test25);
+    E_INFO("%d\n", mem[0]);
+    E_INFO("%d\n", mem[1]);
+    E_INFO("%d\n", mem[2]);
+    E_INFO("%d\n", mem[3]);
+    for (address.offset = 0; address.offset < 57 * 8; address.offset += 25) {
+      uint64 read25 = bitarr_read_int25(address, 25, ((1UL << 25) - 1));
+      E_INFO("Testing %lx at %d = %lx\n", test25, address.offset, read25);
+      TEST_EQUAL(test25, read25);
+    }
+    /* Test arbitrary addresses */
+    for (address.offset = 0; address.offset < 57 * 8; address.offset += 1) {
+      uint64 read25;
+
+      bitarr_write_int25(address, 25, test25);
+      read25 = bitarr_read_int25(address, 25, ((1UL << 25) - 1));
+      E_INFO("Testing %lx at %d = %lx\n", test25, address.offset, read25);
+      TEST_EQUAL(test25, read25);
+      memset(mem, 0, sizeof(mem));
+    }
     return 0;
 }


### PR DESCRIPTION
All tests should now pass on S390, and, presumably, other big-endian machines.  Should notably fix https://github.com/cmusphinx/pocketsphinx/issues/252

I don't know who wrote the bitarr and lm_trie code but I would like a word with them.  It is undocumented and inscrutable and the fact that it is full of assumptions that make it break on other architectures doesn't give me confidence in its correctness or security.