### PR TITLE
Update -cmninit parameter when CMN is updated

### DIFF
--- a/include/pocketsphinx/ps_search.h
+++ b/include/pocketsphinx/ps_search.h
@@ -297,7 +297,10 @@ int ps_set_allphone_file(ps_decoder_t *ps, const char *name, const char *path);
 /**
  * Adds new search based on forced alignment.
  *
- * Convenient method to and create a forced aligner for a piece of text.
+ * Convenient method to and create a forced aligner for a piece of
+ * text.  Note that this is currently less than useful, as it depends
+ * on the word sequence exactly matching the input, including
+ * alternate pronunciations and silences.
  *
  * @param ps Decoder
  * @param name Name for this search (could be anything, such as an utterance

--- a/include/sphinxbase/cmn.h
+++ b/include/sphinxbase/cmn.h
@@ -126,9 +126,9 @@ cmn_type_t cmn_type_from_str(const char *str);
  */
 
 typedef struct {
-    mfcc_t *cmn_mean;   /**< Temporary variable: current means */
-    mfcc_t *cmn_var;    /**< Temporary variables: stored the cmn variance */
-    mfcc_t *sum;        /**< The sum of the cmn frames */
+    mfcc_t *cmn_mean;   /**< Current means */
+    mfcc_t *cmn_var;    /**< Stored cmn variance */
+    mfcc_t *sum;        /**< Accumulated cepstra for computing mean */
     int32 nframe;	/**< Number of frames */
     int32 veclen;	/**< Length of cepstral vector */
 } cmn_t;
@@ -173,12 +173,6 @@ void cmn_live_update(cmn_t *cmn);
  */
 SPHINXBASE_EXPORT
 void cmn_live_set(cmn_t *cmn, mfcc_t const *vec);
-
-/**
- * Get the live mean.
- */
-SPHINXBASE_EXPORT
-void cmn_live_get(cmn_t *cmn, mfcc_t *vec);
 
 /* RAH, free previously allocated memory */
 SPHINXBASE_EXPORT

--- a/src/acmod.h
+++ b/src/acmod.h
@@ -223,10 +223,16 @@ POCKETSPHINX_EXPORT
 acmod_t *acmod_init(cmd_ln_t *config, logmath_t *lmath, fe_t *fe, feat_t *fcb);
 
 /**
+ * Reinitialize feature computation modules.
+ */
+POCKETSPHINX_EXPORT
+int acmod_reinit_feat(acmod_t *acmod, fe_t *fe, feat_t *fcb);
+
+/**
  * Verify that feature extraction parameters are compatible with
  * acoustic model.
  *
-  * @param fe acoustic feature extraction module to verify.
+ * @param fe acoustic feature extraction module to verify.
  * @return TRUE if compatible, FALSE otherwise
  */
 POCKETSPHINX_EXPORT

--- a/src/feat/cmn_live.c
+++ b/src/feat/cmn_live.c
@@ -69,16 +69,6 @@ cmn_live_set(cmn_t *cmn, mfcc_t const * vec)
     E_INFOCONT(">\n");
 }
 
-void
-cmn_live_get(cmn_t *cmn, mfcc_t * vec)
-{
-    int32 i;
-
-    for (i = 0; i < cmn->veclen; i++)
-        vec[i] = cmn->cmn_mean[i];
-
-}
-
 static void
 cmn_live_shiftwin(cmn_t *cmn)
 {

--- a/src/pocketsphinx.c
+++ b/src/pocketsphinx.c
@@ -213,24 +213,14 @@ ps_default_search_args(cmd_ln_t *config)
 #endif
 }
 
-fe_t *
-ps_reinit_fe(ps_decoder_t *ps, cmd_ln_t *config)
+int
+ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config)
 {
-    fe_t *new_fe;
-    
     if (config && config != ps->config) {
         cmd_ln_free_r(ps->config);
         ps->config = cmd_ln_retain(config);
     }
-    if ((new_fe = fe_init_auto_r(ps->config)) == NULL)
-        return NULL;
-    if (acmod_fe_mismatch(ps->acmod, new_fe)) {
-        fe_free(new_fe);
-        return NULL;
-    }
-    fe_free(ps->acmod->fe);
-    ps->acmod->fe = new_fe;
-    return new_fe;
+    return acmod_reinit_feat(ps->acmod, NULL, NULL);
 }
 
 int

--- a/src/util/cmd_ln.c
+++ b/src/util/cmd_ln.c
@@ -780,7 +780,6 @@ cmd_ln_parse_file_r(cmd_ln_t *inout_cmdln, const arg_t * defn, const char *filen
 void
 cmd_ln_log_help_r(cmd_ln_t *cmdln, arg_t const* defn)
 {
-
     if (defn == NULL)
         return;
     E_INFO("Arguments list definition:\n");

--- a/test/unit/test_acmod.c
+++ b/test/unit/test_acmod.c
@@ -3,6 +3,7 @@
 #include <pocketsphinx.h>
 
 #include <sphinxbase/logmath.h>
+#include <sphinxbase/err.h>
 
 #include "acmod.h"
 #include "test_macros.h"
@@ -40,6 +41,7 @@ main(int argc, char *argv[])
 
     (void)argc;
     (void)argv;
+    err_set_loglevel(ERR_INFO);
     lmath = logmath_init(1.0001, 0, 0);
     config = cmd_ln_init(NULL, ps_args(), TRUE,
                  "-compallsen", "true",
@@ -63,6 +65,8 @@ main(int argc, char *argv[])
     cmd_ln_set_str_extra_r(config, "_lda", NULL);
     cmd_ln_set_str_extra_r(config, "_senmgau", NULL);	
 
+    /* Unset -cmninit to avoid confusion */
+    cmd_ln_set_str_r(config, "-cmninit", NULL);
     TEST_ASSERT(acmod = acmod_init(config, lmath, NULL, NULL));
     cmn_live_set(acmod->fcb->cmn_struct, cmninit);
 
@@ -93,6 +97,9 @@ main(int argc, char *argv[])
         }
     }
     TEST_EQUAL(0, acmod_end_utt(acmod));
+    /* Make sure -cmninit was updated. */
+    TEST_ASSERT(cmd_ln_str_r(config, "-cmninit") != NULL);
+    E_INFO("New -cmninit: %s\n", cmd_ln_str_r(config, "-cmninit"));
     nread = 0;
     {
         int16 best_score;
@@ -123,6 +130,9 @@ main(int argc, char *argv[])
     TEST_EQUAL(0, acmod_start_utt(acmod));
     acmod_process_raw(acmod, &bptr, &nsamps, TRUE);
     TEST_EQUAL(0, acmod_end_utt(acmod));
+    /* Make sure -cmninit was updated. */
+    TEST_ASSERT(cmd_ln_str_r(config, "-cmninit") != NULL);
+    E_INFO("New -cmninit: %s\n", cmd_ln_str_r(config, "-cmninit"));
     {
         int16 best_score;
         int frame_idx = -1, best_senid;
@@ -175,6 +185,9 @@ main(int argc, char *argv[])
         }
     }
     TEST_EQUAL(0, acmod_end_utt(acmod));
+    /* Make sure -cmninit was updated. */
+    TEST_ASSERT(cmd_ln_str_r(config, "-cmninit") != NULL);
+    E_INFO("New -cmninit: %s\n", cmd_ln_str_r(config, "-cmninit"));
     nfr = 0;
     acmod_process_cep(acmod, &cptr, &nfr, FALSE);
     {
@@ -210,6 +223,9 @@ main(int argc, char *argv[])
     nfr = frame_counter;
     acmod_process_cep(acmod, &cptr, &nfr, TRUE);
     TEST_EQUAL(0, acmod_end_utt(acmod));
+    /* Make sure -cmninit was updated. */
+    TEST_ASSERT(cmd_ln_str_r(config, "-cmninit") != NULL);
+    E_INFO("New -cmninit: %s\n", cmd_ln_str_r(config, "-cmninit"));
     {
         int16 best_score;
         int frame_idx = -1, best_senid;

--- a/test/unit/test_reinit.c
+++ b/test/unit/test_reinit.c
@@ -9,6 +9,7 @@ main(int argc, char *argv[])
 {
 	ps_decoder_t *ps;
 	cmd_ln_t *config;
+        char *pron;
 
 	(void)argc;
 	(void)argv;
@@ -31,8 +32,25 @@ main(int argc, char *argv[])
 	ps_add_word(ps, "foobie", "F UW B IY", FALSE);
 	ps_add_word(ps, "hellosomething", "HH EH L OW S", TRUE);
 
+        /* Reinit features only, words should remain */
+        cmd_ln_set_str_r(config, "-cmninit", "41,-4,1");
+	TEST_EQUAL(0, ps_reinit_feat(ps, config));
+        TEST_EQUAL(0, strcmp(cmd_ln_str_r(ps_get_config(ps), "-cmninit"),
+                             "41,-4,1"));
+        pron = ps_lookup_word(ps, "foobie");
+        TEST_ASSERT(pron != NULL);
+        TEST_EQUAL(0, strcmp(pron, "F UW B IY"));
+        ckd_free(pron);
+
 	/* Reinit with existing config */
 	ps_reinit(ps, NULL);
+        /* Words added above are gone, we expect that. */
+        pron = ps_lookup_word(ps, "foobie");
+        TEST_ASSERT(pron == NULL);
+        /* Unfortunately so are feature params if feat.params is in
+         * AM.  No way around this... */
+        TEST_ASSERT(0 != strcmp(cmd_ln_str_r(ps_get_config(ps), "-cmninit"),
+                                "41,-4,1"));
 
 	ps_free(ps);
 	cmd_ln_free_r(config);


### PR DESCRIPTION
This allows a simple form of enrollment or channel adaptation - the string representation of the current live cepstral mean, as passed to -cmninit, can always be accessed through the configuration object in the decoder, e.g.:

```
printf("current cepstral mean is %s\n", cmd_ln_str_r(ps_get_config(decoder), "-cmninit"));
```

In addition, `ps_reinit_fe()` has been renamed to `ps_reinit_feat()` so as to include modifications to `-cmninit`, VTLN, and other pertinent parameters.