### PR TITLE
Fix install command for Mac and iOS builds

### DIFF
--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -13,4 +13,19 @@ foreach(PROGRAM ${POCKETSPHINX_PROGRAMS})
     ${PROGRAM} PRIVATE ${CMAKE_SOURCE_DIR}/src
     ${PROGRAM} PRIVATE ${CMAKE_BINARY_DIR})
 endforeach()
-install(TARGETS ${POCKETSPHINX_PROGRAMS} RUNTIME)
+
+# The cmake docs indicate you should check MACOSX_BUNDLE
+# and that MACOSX_BUNDLE is initialized based on the value
+# of CMAKE_MACOSX_BUNDLE but in practice, MACOSX_BUNDLE
+# seems blank regardless of the value of CMAKE_MACOSX_BUNDLE.
+# Since MACOSX_BUNDLE seems intended to just forward the value
+# of CMAKE_MACOSX_BUNDLE anyway, we check CMAKE_MACOSX_BUNDLE
+# directly.
+if(CMAKE_MACOSX_BUNDLE)
+  install(TARGETS ${POCKETSPHINX_PROGRAMS}
+          RUNTIME DESTINATION bin
+          BUNDLE DESTINATION bin
+  )
+else()
+  install(TARGETS ${POCKETSPHINX_PROGRAMS} RUNTIME)
+endif()


### PR DESCRIPTION
Currently, when building for iOS or Mac (in my case, building for iOS, I have `CMAKE_SYSTEM_NAME = iOS` ), you'll get this error:

```
CMake Error at programs/CMakeLists.txt:16 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "pocketsphinx_batch".
```

Reference to doc mentioned in comment: https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE.html#prop_tgt:MACOSX_BUNDLE