### PR TITLE
Add a proper API for cepstral mean normalization

### DIFF
--- a/cython/_pocketsphinx.pxd
+++ b/cython/_pocketsphinx.pxd
@@ -341,6 +341,8 @@ cdef extern from "pocketsphinx.h":
     int ps_free(ps_decoder_t *ps)
     int ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
     int ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config)
+    const char *ps_get_cmn(ps_decoder_t *ps, int update)
+    int ps_set_cmn(ps_decoder_t *ps, const char *cmn)
     logmath_t *ps_get_logmath(ps_decoder_t *ps)
     int ps_start_stream(ps_decoder_t *ps)
     int ps_get_in_speech(ps_decoder_t *ps)

--- a/cython/test/continuous_test.py
+++ b/cython/test/continuous_test.py
@@ -14,30 +14,30 @@ class TestContinuous(unittest.TestCase):
         config.set_string("-hmm", os.path.join(MODELDIR, "en-us/en-us"))
         config.set_string("-lm", os.path.join(MODELDIR, "en-us/en-us.lm.bin"))
         config.set_string("-dict", os.path.join(MODELDIR, "en-us/cmudict-en-us.dict"))
-        config.set_string(
-            "-cmninit",
-            "41.00,-5.29,-0.12,5.09,2.48,-4.07,-1.37,-1.78,-5.08,-2.05,-6.45,-1.42,1.17",
+        prev_cmn = (
+            "41,-5.29,-0.12,5.09,2.48,-4.07,-1.37,-1.78,-5.08,-2.05,-6.45,-1.42,1.17"
         )
+        config.set_string("-cmninit", prev_cmn)
         decoder = Decoder(config)
+        self.assertEqual(prev_cmn, decoder.get_cmn(False))
 
         with open(os.path.join(DATADIR, "goforward.raw"), "rb") as stream:
-            in_speech_bf = False
             decoder.start_utt()
             while True:
                 buf = stream.read(1024)
                 if buf:
                     decoder.process_raw(buf, False, False)
-                    if decoder.get_in_speech() != in_speech_bf:
-                        in_speech_bf = decoder.get_in_speech()
-                        if not in_speech_bf:
-                            decoder.end_utt()
-                            print('Result:', decoder.hyp().hypstr)
-                            decoder.start_utt()
+                    cmn = decoder.get_cmn(True)
+                    self.assertNotEqual(prev_cmn, cmn)
+                    prev_cmn = cmn
                 else:
                     break
             decoder.end_utt()
             print("Result:", decoder.hyp().hypstr)
             self.assertEqual("go forward ten meters", decoder.hyp().hypstr)
+            cmn = decoder.get_cmn(False)
+            self.assertNotEqual(prev_cmn, cmn)
+            prev_cmn = cmn
 
 
 if __name__ == "__main__":

--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -139,12 +139,13 @@ int ps_reinit(ps_decoder_t *ps, cmd_ln_t *config);
  *
  * This function allows you to switch the feature computation
  * parameters without otherwise affecting the decoder configuration.
- * For example, if you change the sample rate or the frame rate, the
- * cepstral mean, or the VTLN warping factor, and do not need to
- * reconfigure the rest of the decoder.
+ * For example, if you change the sample rate or the frame rate, and
+ * do not want to reconfigure the rest of the decoder.
  *
  * Note that if your code has modified any internal parameters in the
  * \ref acmod_t, these will be overriden by values from the config.
+ * Likewise if you have set a custom cepstral mean with ps_set_cmn(),
+ * it will be overridden.
  *
  * @note The decoder retains ownership of the pointer `config`, so you
  * should free it when no longer used.
@@ -157,6 +158,39 @@ int ps_reinit(ps_decoder_t *ps, cmd_ln_t *config);
  */
 POCKETSPHINX_EXPORT
 int ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config);
+
+/**
+ * Get the current cepstral mean as a string.
+ *
+ * This is the string representation of the current cepstral mean,
+ * which represents the acoustic channel conditions in live
+ * recognition.  This can be used to initialize the decoder with the
+ * `-cmninit` flag.
+ *
+ * @param ps Decoder
+ * @return String representation of cepstral mean, as
+ *         `-ceplen` comma-separated numbers.  This pointer is owned
+ *         by the decoder and only valid until the next call to
+ *         ps_set_cmn() or ps_end_utt().
+ */
+POCKETSPHINX_EXPORT
+const char *ps_get_cmn(ps_decoder_t *ps);
+
+/**
+ * Set the current cepstral mean from a string.
+ *
+ * This does the same thing as setting `-cmninit` and running
+ * `ps_reinit_feat()` but is more efficient, and can also be
+ * done in the middle of an utterance if you like.
+ *
+ * @param ps Decoder
+ * @param cmn String representation of cepstral mean, as
+ *            up to `-ceplen` comma-separated numbers (any
+ *            missing values will be zero-filled).
+ * @return 0 for success of -1 for invalid input.
+ */
+POCKETSPHINX_EXPORT
+int ps_set_cmn(ps_decoder_t *ps, const char *cmn);
 
 /**
  * Returns the argument definitions used in ps_init().

--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -168,13 +168,14 @@ int ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config);
  * `-cmninit` flag.
  *
  * @param ps Decoder
+ * @param update Update the cepstral mean using data processed so far.
  * @return String representation of cepstral mean, as
  *         `-ceplen` comma-separated numbers.  This pointer is owned
  *         by the decoder and only valid until the next call to
- *         ps_set_cmn() or ps_end_utt().
+ *         ps_get_cmn(), ps_set_cmn() or ps_end_utt().
  */
 POCKETSPHINX_EXPORT
-const char *ps_get_cmn(ps_decoder_t *ps);
+const char *ps_get_cmn(ps_decoder_t *ps, int update);
 
 /**
  * Set the current cepstral mean from a string.

--- a/include/sphinxbase/cmn.h
+++ b/include/sphinxbase/cmn.h
@@ -189,7 +189,7 @@ const char *cmn_update_repr(cmn_t *cmn);
  * Set the live mean from a string.
  */
 SPHINXBASE_EXPORT
-void cmn_set_repr(cmn_t *cmn, char const *repr);
+int cmn_set_repr(cmn_t *cmn, char const *repr);
 
 /**
  * Retain a CMN.

--- a/include/sphinxbase/cmn.h
+++ b/include/sphinxbase/cmn.h
@@ -131,6 +131,8 @@ typedef struct {
     mfcc_t *sum;        /**< Accumulated cepstra for computing mean */
     int32 nframe;	/**< Number of frames */
     int32 veclen;	/**< Length of cepstral vector */
+    char *repr;         /**< String representation of current means */
+    int refcount;
 } cmn_t;
 
 SPHINXBASE_EXPORT
@@ -169,14 +171,36 @@ SPHINXBASE_EXPORT
 void cmn_live_update(cmn_t *cmn);
 
 /**
- * Set the live mean.
+ * Set live mean from a vector of length cmn->veclen
+ */
+void cmn_live_set(cmn_t *cmn, mfcc_t const * vec);
+
+/**
+ * Get the string representation of the live mean.
+ */
+#define cmn_repr(cmn) (cmn)->repr
+
+/**
+ * Update the string representation.
+ */
+const char *cmn_update_repr(cmn_t *cmn);
+
+/**
+ * Set the live mean from a string.
  */
 SPHINXBASE_EXPORT
-void cmn_live_set(cmn_t *cmn, mfcc_t const *vec);
+void cmn_set_repr(cmn_t *cmn, char const *repr);
 
-/* RAH, free previously allocated memory */
+/**
+ * Retain a CMN.
+ */
+cmn_t *cmn_retain(cmn_t *cmn);
+
+/**
+ * Release a CMN, possibly freeing it.
+ */
 SPHINXBASE_EXPORT
-void cmn_free (cmn_t *cmn);
+int cmn_free (cmn_t *cmn);
 
 #ifdef __cplusplus
 }

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -446,7 +446,11 @@ acmod_end_utt(acmod_t *acmod)
         /* Process whatever's left, and any leadout. */
         if (nfr)
             nfr = acmod_process_mfcbuf(acmod);
+        else /* Make sure to update CMN! */
+            feat_update_stats(acmod->fcb);
     }
+    else /* Make sure to update CMN! */
+        feat_update_stats(acmod->fcb);
     if (acmod->mfcfh) {
         int32 outlen, rv;
         outlen = (ftell(acmod->mfcfh) - 4) / 4;

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -65,7 +65,6 @@
 #include "ms_mgau.h"
 
 static int32 acmod_process_mfcbuf(acmod_t *acmod);
-static const char *acmod_update_cmninit(acmod_t *acmod);
 
 static int
 acmod_init_am(acmod_t *acmod)
@@ -196,23 +195,8 @@ acmod_reinit_feat(acmod_t *acmod, fe_t *fe, feat_t *fcb)
         if (fcb->cmn_struct
             && cmd_ln_exists_r(acmod->config, "-cmninit")
             && cmd_ln_str_r(acmod->config, "-cmninit")) {
-            char *c, *cc, *vallist;
-            int32 nvals;
-
-            vallist = ckd_salloc(cmd_ln_str_r(acmod->config, "-cmninit"));
-            c = vallist;
-            nvals = 0;
-            while (nvals < fcb->cmn_struct->veclen
-                   && (cc = strchr(c, ',')) != NULL) {
-                *cc = '\0';
-                fcb->cmn_struct->cmn_mean[nvals] = FLOAT2MFCC(atof_c(c));
-                c = cc + 1;
-                ++nvals;
-            }
-            if (nvals < fcb->cmn_struct->veclen && *c != '\0') {
-                fcb->cmn_struct->cmn_mean[nvals] = FLOAT2MFCC(atof_c(c));
-            }
-            ckd_free(vallist);
+            E_INFO("Setting initial CMN to %s\n", cmd_ln_str_r(acmod->config, "-cmninit"));
+            cmn_set_repr(fcb->cmn_struct, cmd_ln_str_r(acmod->config, "-cmninit"));
         }
     }
     if (acmod_feat_mismatch(acmod, fcb)) {
@@ -484,43 +468,7 @@ acmod_end_utt(acmod_t *acmod)
         acmod->senfh = NULL;
     }
 
-    acmod_update_cmninit(acmod);
-
     return nfr;
-}
-
-static const char *
-acmod_update_cmninit(acmod_t *acmod)
-{
-    char *cmninit, *ptr;
-    cmn_t *cmn;
-    int i, len;
-    
-    if (acmod->fcb == NULL)
-        return NULL;
-    if ((cmn = acmod->fcb->cmn_struct) == NULL)
-        return NULL;
-    len = 0;
-    for (i = 0; i < cmn->veclen; ++i) {
-        int nbytes = snprintf(NULL, 0, "%g,", cmn->cmn_mean[i]);
-        if (nbytes <= 0) {
-            E_ERROR_SYSTEM("Failed to format %g for cmninit", cmn->cmn_mean[i]);
-            return NULL;
-        }
-        len += nbytes;
-    }
-    len++;
-    ptr = cmninit = ckd_malloc(len);
-    if (ptr == NULL) {
-        E_ERROR_SYSTEM("Failed to allocate %d bytes for cmninit", len);
-        return NULL;
-    }
-    for (i = 0; i < cmn->veclen; ++i)
-        ptr += snprintf(ptr, cmninit + len - ptr, "%g,", cmn->cmn_mean[i]);
-    *--ptr = '\0';
-    cmd_ln_set_str_r(acmod->config, "-cmninit", cmninit);
-    ckd_free(cmninit);
-    return cmd_ln_str_r(acmod->config, "-cmninit");
 }
 
 static int

--- a/src/feat/cmn.c
+++ b/src/feat/cmn.c
@@ -54,6 +54,8 @@
 #include "sphinxbase/ckd_alloc.h"
 #include "sphinxbase/err.h"
 #include "sphinxbase/cmn.h"
+#include "sphinxbase/strfuncs.h"
+#include "sphinxbase/feat.h"
 
 /* NOTE!  These must match the enum in cmn.h */
 const char *cmn_type_str[] = {
@@ -81,16 +83,74 @@ cmn_type_from_str(const char *str)
     return CMN_NONE;
 }
 
+const char *
+cmn_update_repr(cmn_t *cmn)
+{
+    char *ptr;
+    int i, len;
+    
+    len = 0;
+    for (i = 0; i < cmn->veclen; ++i) {
+        int nbytes = snprintf(NULL, 0, "%g,", cmn->cmn_mean[i]);
+        if (nbytes <= 0) {
+            E_ERROR_SYSTEM("Failed to format %g for cmninit", cmn->cmn_mean[i]);
+            return NULL;
+        }
+        len += nbytes;
+    }
+    len++;
+    if (cmn->repr)
+        ckd_free(cmn->repr);
+    ptr = cmn->repr = ckd_malloc(len);
+    if (ptr == NULL) {
+        E_ERROR_SYSTEM("Failed to allocate %d bytes for cmn string", len);
+        return NULL;
+    }
+    for (i = 0; i < cmn->veclen; ++i)
+        ptr += snprintf(ptr, cmn->repr + len - ptr, "%g,", cmn->cmn_mean[i]);
+    *--ptr = '\0';
+
+    return cmn->repr;
+}
+
+void
+cmn_set_repr(cmn_t *cmn, const char *repr)
+{
+    char *c, *cc, *vallist;
+    int32 nvals;
+
+    E_INFO("Update from < %s >\n", cmn->repr);
+    vallist = ckd_salloc(repr);
+    c = vallist;
+    nvals = 0;
+    while (nvals < cmn->veclen
+           && (cc = strchr(c, ',')) != NULL) {
+        *cc = '\0';
+        cmn->cmn_mean[nvals] = FLOAT2MFCC(atof_c(c));
+        cmn->sum[nvals] = cmn->cmn_mean[nvals] * CMN_WIN;
+        c = cc + 1;
+        ++nvals;
+    }
+    if (nvals < cmn->veclen && *c != '\0') {
+        cmn->cmn_mean[nvals] = FLOAT2MFCC(atof_c(c));
+        cmn->sum[nvals] = cmn->cmn_mean[nvals] * CMN_WIN;
+    }
+    ckd_free(vallist);
+    E_INFO("Update to   < %s >\n", cmn_update_repr(cmn));
+}
+
 cmn_t *
 cmn_init(int32 veclen)
 {
     cmn_t *cmn;
     cmn = (cmn_t *) ckd_calloc(1, sizeof(cmn_t));
+    cmn->refcount = 1;
     cmn->veclen = veclen;
     cmn->cmn_mean = (mfcc_t *) ckd_calloc(veclen, sizeof(mfcc_t));
     cmn->cmn_var = (mfcc_t *) ckd_calloc(veclen, sizeof(mfcc_t));
     cmn->sum = (mfcc_t *) ckd_calloc(veclen, sizeof(mfcc_t));
     cmn->nframe = 0;
+    cmn_update_repr(cmn);
 
     return cmn;
 }
@@ -130,10 +190,7 @@ cmn(cmn_t *cmn, mfcc_t ** mfc, int32 varnorm, int32 n_frame)
     for (i = 0; i < cmn->veclen; i++)
         cmn->cmn_mean[i] /= n_pos_frame;
 
-    E_INFO("CMN: ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT("\n");
+    E_INFO("CMN: %s\n", cmn_update_repr(cmn));
     if (!varnorm) {
         /* Subtract mean from each cep vector */
         for (f = 0; f < n_frame; f++) {
@@ -167,22 +224,28 @@ cmn(cmn_t *cmn, mfcc_t ** mfc, int32 varnorm, int32 n_frame)
     }
 }
 
-/* 
- * RAH, free previously allocated memory
- */
-void
+int
 cmn_free(cmn_t * cmn)
 {
-    if (cmn != NULL) {
-        if (cmn->cmn_var)
-            ckd_free((void *) cmn->cmn_var);
+    if (cmn == NULL)
+        return 0;
+    if (--cmn->refcount > 0)
+        return cmn->refcount;
+    if (cmn->cmn_var)
+        ckd_free(cmn->cmn_var);
+    if (cmn->cmn_mean)
+        ckd_free(cmn->cmn_mean);
+    if (cmn->sum)
+        ckd_free(cmn->sum);
+    if (cmn->repr)
+        ckd_free(cmn->repr);
+    ckd_free(cmn);
+    return 0;
+}
 
-        if (cmn->cmn_mean)
-            ckd_free((void *) cmn->cmn_mean);
-
-        if (cmn->sum)
-            ckd_free((void *) cmn->sum);
-
-        ckd_free((void *) cmn);
-    }
+cmn_t *
+cmn_retain(cmn_t *cmn)
+{
+    ++cmn->refcount;
+    return cmn;
 }

--- a/src/feat/cmn.c
+++ b/src/feat/cmn.c
@@ -113,13 +113,15 @@ cmn_update_repr(cmn_t *cmn)
     return cmn->repr;
 }
 
-void
+int
 cmn_set_repr(cmn_t *cmn, const char *repr)
 {
     char *c, *cc, *vallist;
     int32 nvals;
 
     E_INFO("Update from < %s >\n", cmn->repr);
+    memset(cmn->cmn_mean, 0, sizeof(cmn->cmn_mean[0]) * cmn->veclen);
+    memset(cmn->sum, 0, sizeof(cmn->sum[0]) * cmn->veclen);
     vallist = ckd_salloc(repr);
     c = vallist;
     nvals = 0;
@@ -137,6 +139,7 @@ cmn_set_repr(cmn_t *cmn, const char *repr)
     }
     ckd_free(vallist);
     E_INFO("Update to   < %s >\n", cmn_update_repr(cmn));
+    return 0;
 }
 
 cmn_t *

--- a/src/feat/cmn_live.c
+++ b/src/feat/cmn_live.c
@@ -52,21 +52,13 @@ cmn_live_set(cmn_t *cmn, mfcc_t const * vec)
 {
     int32 i;
 
-    E_INFO("Update from < ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT(">\n");
-
+    E_INFO("Update from < %s >\n", cmn->repr);
     for (i = 0; i < cmn->veclen; i++) {
         cmn->cmn_mean[i] = vec[i];
         cmn->sum[i] = vec[i] * CMN_WIN;
     }
     cmn->nframe = CMN_WIN;
-
-    E_INFO("Update to   < ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT(">\n");
+    E_INFO("Update to   < %s >\n", cmn_update_repr(cmn));
 }
 
 static void
@@ -75,11 +67,7 @@ cmn_live_shiftwin(cmn_t *cmn)
     mfcc_t sf;
     int32 i;
 
-    E_INFO("Update from < ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT(">\n");
-
+    E_INFO("Update from < %s >\n", cmn->repr);
     sf = FLOAT2MFCC(1.0) / cmn->nframe;
     for (i = 0; i < cmn->veclen; i++)
         cmn->cmn_mean[i] = cmn->sum[i] / cmn->nframe; /* sum[i] * sf */
@@ -91,11 +79,7 @@ cmn_live_shiftwin(cmn_t *cmn)
             cmn->sum[i] = MFCCMUL(cmn->sum[i], sf);
         cmn->nframe = CMN_WIN;
     }
-
-    E_INFO("Update to   < ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT(">\n");
+    E_INFO("Update to   < %s >\n", cmn_update_repr(cmn));
 }
 
 void
@@ -107,11 +91,7 @@ cmn_live_update(cmn_t *cmn)
     if (cmn->nframe <= 0)
         return;
 
-    E_INFO("Update from < ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT(">\n");
-
+    E_INFO("Update from < %s >\n", cmn->repr);
     /* Update mean buffer */
     sf = FLOAT2MFCC(1.0) / cmn->nframe;
     for (i = 0; i < cmn->veclen; i++)
@@ -124,11 +104,7 @@ cmn_live_update(cmn_t *cmn)
             cmn->sum[i] = MFCCMUL(cmn->sum[i], sf);
         cmn->nframe = CMN_WIN;
     }
-
-    E_INFO("Update to   < ");
-    for (i = 0; i < cmn->veclen; i++)
-        E_INFOCONT("%5.2f ", MFCC2FLOAT(cmn->cmn_mean[i]));
-    E_INFOCONT(">\n");
+    E_INFO("Update to   < %s >\n", cmn_update_repr(cmn));
 }
 
 void

--- a/src/pocketsphinx.c
+++ b/src/pocketsphinx.c
@@ -408,6 +408,19 @@ ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
     return 0;
 }
 
+const char *
+ps_get_cmn(ps_decoder_t *ps)
+{
+    return cmn_repr(ps->acmod->fcb->cmn_struct);
+}
+
+int
+ps_set_cmn(ps_decoder_t *ps, const char *cmn)
+{
+    return cmn_set_repr(ps->acmod->fcb->cmn_struct, cmn);
+}
+
+
 ps_decoder_t *
 ps_init(cmd_ln_t *config)
 {

--- a/src/pocketsphinx.c
+++ b/src/pocketsphinx.c
@@ -409,8 +409,10 @@ ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
 }
 
 const char *
-ps_get_cmn(ps_decoder_t *ps)
+ps_get_cmn(ps_decoder_t *ps, int update)
 {
+    if (update)
+        cmn_live_update(ps->acmod->fcb->cmn_struct);
     return cmn_repr(ps->acmod->fcb->cmn_struct);
 }
 

--- a/test/unit/test_acmod.c
+++ b/test/unit/test_acmod.c
@@ -24,6 +24,16 @@ static const mfcc_t cmninit[13] = {
 	FLOAT2MFCC(1.17)
 };
 
+static void
+assert_cmninit(cmn_t *cmn)
+{
+    int i;
+    for (i = 0; i < cmn->veclen; ++i) {
+        TEST_EQUAL_FLOAT(cmn->cmn_mean[i], cmninit[i]);
+        TEST_EQUAL_FLOAT(cmn->sum[i], cmninit[i] * CMN_WIN);
+    }
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -65,10 +75,17 @@ main(int argc, char *argv[])
     cmd_ln_set_str_extra_r(config, "_lda", NULL);
     cmd_ln_set_str_extra_r(config, "_senmgau", NULL);	
 
-    /* Unset -cmninit to avoid confusion */
-    cmd_ln_set_str_r(config, "-cmninit", NULL);
+    /* Ensure that -cmninit does what it should */
+    cmd_ln_set_str_r(config, "-cmninit",
+                     "41.00,-5.29,-0.12,5.09,2.48,-4.07,-1.37,-1.78,-5.08,-2.05,-6.45,-1.42,1.17");
     TEST_ASSERT(acmod = acmod_init(config, lmath, NULL, NULL));
+    assert_cmninit(acmod->fcb->cmn_struct);
+    /* Ensure that the two different ways of setting CMN do the right thing. */
     cmn_live_set(acmod->fcb->cmn_struct, cmninit);
+    assert_cmninit(acmod->fcb->cmn_struct);
+    cmn_set_repr(acmod->fcb->cmn_struct, 
+                 "41.00,-5.29,-0.12,5.09,2.48,-4.07,-1.37,-1.78,-5.08,-2.05,-6.45,-1.42,1.17");
+    assert_cmninit(acmod->fcb->cmn_struct);
 
     nsamps = 2048;
     frame_counter = 0;


### PR DESCRIPTION
The hack with the "-cmninit" parameter really didn't work right, and also, it prevented us from doing cool (maybe useful) things like setting and getting the CMN in the middle of an utterance.