### PR TITLE
Begin the cleanup of the configuration API

### DIFF
--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -69,6 +69,12 @@ extern "C" {
  */
 typedef struct ps_decoder_s ps_decoder_t;
 
+/**
+ * @struct ps_config_t
+ * PocketSphinx configuration object.
+ */
+typedef struct cmd_ln_s ps_config_t;
+
 /* Voice activity detection. */
 #include <pocketsphinx/vad.h>
 
@@ -91,11 +97,26 @@ typedef struct ps_astar_s ps_nbest_t;
 typedef struct ps_seg_s ps_seg_t;
 
 /**
+ * Parses arguments from the command-line into a configuration.
+ */
+#define ps_config_parse_args(argc, argv) cmd_ln_parse_r(NULL, ps_args(), argc, argv, FALSE)
+
+/**
+ * Retains a pointer to a configuration object.
+ */
+#define ps_config_retain(config) cmd_ln_retain(config)
+
+/**
+ * Releases a configuration object.
+ */
+#define ps_config_free(config) cmd_ln_free_r(config)
+
+/**
  * Sets default grammar and language model if they are not set explicitly and
  * are present in the default search path.
  */
 POCKETSPHINX_EXPORT
-void ps_default_search_args(cmd_ln_t *);
+void ps_default_search_args(ps_config_t *);
 
 /**
  * Gets the system default model directory, if any exists.
@@ -120,7 +141,7 @@ const char *ps_default_modeldir(void);
  * proceed to initialize it with ps_reinit().
  */
 POCKETSPHINX_EXPORT
-ps_decoder_t *ps_init(cmd_ln_t *config);
+ps_decoder_t *ps_init(ps_config_t *config);
 
 /**
  * Reinitialize the decoder with updated configuration.
@@ -145,7 +166,7 @@ ps_decoder_t *ps_init(cmd_ln_t *config);
  * @return 0 for success, <0 for failure.
  */
 POCKETSPHINX_EXPORT
-int ps_reinit(ps_decoder_t *ps, cmd_ln_t *config);
+int ps_reinit(ps_decoder_t *ps, ps_config_t *config);
 
 /**
  * Reinitialize only the feature computation with updated configuration.
@@ -170,7 +191,7 @@ int ps_reinit(ps_decoder_t *ps, cmd_ln_t *config);
  * @return 0 for success, <0 for failure (usually an invalid parameter)
  */
 POCKETSPHINX_EXPORT
-int ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config);
+int ps_reinit_feat(ps_decoder_t *ps, ps_config_t *config);
 
 /**
  * Get the current cepstral mean as a string.
@@ -248,7 +269,7 @@ int ps_free(ps_decoder_t *ps);
  *         elsewhere.
  */
 POCKETSPHINX_EXPORT
-cmd_ln_t *ps_get_config(ps_decoder_t *ps);
+ps_config_t *ps_get_config(ps_decoder_t *ps);
 
 /**
  * Get the log-math computation object for this decoder.
@@ -694,10 +715,10 @@ void ps_get_all_time(ps_decoder_t *ps, double *out_nspeech,
                      double *out_ncpu, double *out_nwall);
 
 /**
- * @mainpage PocketSphinx Documentation
+ * @mainpage PocketSphinx API Documentation
  * @author David Huggins-Daines <dhdaines@gmail.com>
- * @version 5.0.0rc1
- * @date August 24, 2022
+ * @version 5.0.0rc2
+ * @date August 26, 2022
  *
  * @section intro_sec Introduction
  *
@@ -766,11 +787,13 @@ void ps_get_all_time(ps_decoder_t *ps, double *out_nspeech,
  * @section programming_sec Using the Library
  *
  * The Python interface is documented at
- * http://pocketsphinx5.readthedocs.io/.  Here is a full example:
+ * http://pocketsphinx5.readthedocs.io/.  Here is a full example,
+ * which will be explained in more detail soon:
  *
  * @include live.py
  *
- * Here is a complete example of using the C programming interface:
+ * Here is a complete example of using the C programming interface,
+ * which will be explained in more detail soon:
  *
  * @include live.c
  *

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -258,7 +258,7 @@ acmod_feat_mismatch(acmod_t *acmod, feat_t *fcb)
 }
 
 acmod_t *
-acmod_init(cmd_ln_t *config, logmath_t *lmath, fe_t *fe, feat_t *fcb)
+acmod_init(ps_config_t *config, logmath_t *lmath, fe_t *fe, feat_t *fcb)
 {
     acmod_t *acmod;
 

--- a/src/acmod.h
+++ b/src/acmod.h
@@ -55,9 +55,10 @@
 #include <sphinxbase/err.h>
 #include <sphinxbase/prim_type.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
-#include <pocketsphinx/mllr.h>
-#include <pocketsphinx/export.h>
 #include "bin_mdef.h"
 #include "tmat.h"
 #include "hmm.h"
@@ -155,7 +156,7 @@ struct ps_mgau_s {
  */
 struct acmod_s {
     /* Global objects, not retained. */
-    cmd_ln_t *config;          /**< Configuration. */
+    ps_config_t *config;          /**< Configuration. */
     logmath_t *lmath;          /**< Log-math computation. */
     glist_t strings;           /**< Temporary acoustic model filenames. */
 
@@ -220,7 +221,7 @@ typedef struct acmod_s acmod_t;
  * @return a newly initialized acmod_t, or NULL on failure.
  */
 POCKETSPHINX_EXPORT
-acmod_t *acmod_init(cmd_ln_t *config, logmath_t *lmath, fe_t *fe, feat_t *fcb);
+acmod_t *acmod_init(ps_config_t *config, logmath_t *lmath, fe_t *fe, feat_t *fcb);
 
 /**
  * Reinitialize feature computation modules.

--- a/src/allphone_search.c
+++ b/src/allphone_search.c
@@ -524,7 +524,7 @@ phmm_trans(allphone_search_t * allphs, int32 best,
 ps_search_t *
 allphone_search_init(const char *name,
                      ngram_model_t * lm,
-                     cmd_ln_t * config,
+                     ps_config_t * config,
                      acmod_t * acmod, dict_t * dict, dict2pid_t * d2p)
 {
     int i;

--- a/src/allphone_search.h
+++ b/src/allphone_search.h
@@ -47,6 +47,9 @@
 #include <sphinxbase/ngram_model.h>
 #include <sphinxbase/bitvec.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
 #include "pocketsphinx_internal.h"
 #include "blkarray_list.h"
@@ -147,7 +150,7 @@ typedef struct allphone_search_s {
  */
 ps_search_t *allphone_search_init(const char *name,
 				  ngram_model_t * lm,
-                                  cmd_ln_t * config,
+                                  ps_config_t * config,
                                   acmod_t * acmod,
                                   dict_t * dict, dict2pid_t * d2p);
 

--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -63,7 +63,7 @@
 #include "bin_mdef.h"
 
 bin_mdef_t *
-bin_mdef_read_text(cmd_ln_t *config, const char *filename)
+bin_mdef_read_text(ps_config_t *config, const char *filename)
 {
     bin_mdef_t *bmdef;
     mdef_t *mdef;
@@ -324,7 +324,7 @@ static const char format_desc[] =
     "END FILE FORMAT DESCRIPTION\n";
 
 bin_mdef_t *
-bin_mdef_read(cmd_ln_t *config, const char *filename)
+bin_mdef_read(ps_config_t *config, const char *filename)
 {
     bin_mdef_t *m;
     FILE *fh;

--- a/src/bin_mdef.h
+++ b/src/bin_mdef.h
@@ -57,6 +57,9 @@ extern "C" {
 #include <sphinxbase/cmd_ln.h>
 #include <pocketsphinx/export.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 #include "mdef.h"
 
 #define BIN_MDEF_FORMAT_VERSION 1
@@ -169,12 +172,12 @@ struct bin_mdef_s {
  * Read a binary mdef from a file.
  */
 POCKETSPHINX_EXPORT
-bin_mdef_t *bin_mdef_read(cmd_ln_t *config, const char *filename);
+bin_mdef_t *bin_mdef_read(ps_config_t *config, const char *filename);
 /**
  * Read a text mdef from a file (creating an in-memory binary mdef).
  */
 POCKETSPHINX_EXPORT
-bin_mdef_t *bin_mdef_read_text(cmd_ln_t *config, const char *filename);
+bin_mdef_t *bin_mdef_read_text(ps_config_t *config, const char *filename);
 /**
  * Write a binary mdef to a file.
  */

--- a/src/dict.c
+++ b/src/dict.c
@@ -250,7 +250,7 @@ dict_write(dict_t *dict, char const *filename, char const *format)
 
 
 dict_t *
-dict_init(cmd_ln_t *config, bin_mdef_t * mdef)
+dict_init(ps_config_t *config, bin_mdef_t * mdef)
 {
     FILE *fp, *fp2;
     int32 n;

--- a/src/dict.h
+++ b/src/dict.h
@@ -45,6 +45,9 @@
 /* SphinxBase headers. */
 #include <sphinxbase/hash_table.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
 #include "s3types.h"
 #include "bin_mdef.h"
@@ -104,7 +107,7 @@ typedef struct dict_s {
  * Return ptr to dict_t if successful, NULL otherwise.
  */
 POCKETSPHINX_EXPORT
-dict_t *dict_init(cmd_ln_t *config, /**< Configuration (-dict, -fdict, -dictcase) or NULL */
+dict_t *dict_init(ps_config_t *config, /**< Configuration (-dict, -fdict, -dictcase) or NULL */
                   bin_mdef_t *mdef  /**< For looking up CI phone IDs (or NULL) */
     );
 

--- a/src/fsg_search.c
+++ b/src/fsg_search.c
@@ -178,7 +178,7 @@ fsg_search_add_altpron(fsg_search_t *fsgs, fsg_model_t *fsg)
 ps_search_t *
 fsg_search_init(const char *name,
 		fsg_model_t *fsg,
-                cmd_ln_t *config,
+                ps_config_t *config,
                 acmod_t *acmod,
                 dict_t *dict,
                 dict2pid_t *d2p)

--- a/src/fsg_search_internal.h
+++ b/src/fsg_search_internal.h
@@ -46,6 +46,9 @@
 #include <sphinxbase/cmd_ln.h>
 #include <sphinxbase/fsg_model.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
 #include "pocketsphinx_internal.h"
 #include "hmm.h"
@@ -121,7 +124,7 @@ typedef struct fsg_search_s {
  */
 ps_search_t *fsg_search_init(const char *name,
 			     fsg_model_t *fsg,
-                             cmd_ln_t *config,
+                             ps_config_t *config,
                              acmod_t *acmod,
                              dict_t *dict,
                              dict2pid_t *d2p);

--- a/src/kws_search.c
+++ b/src/kws_search.c
@@ -376,7 +376,7 @@ ps_search_t *
 kws_search_init(const char *name,
                 const char *keyphrase,
                 const char *keyfile,
-                cmd_ln_t * config,
+                ps_config_t * config,
                 acmod_t * acmod, dict_t * dict, dict2pid_t * d2p)
 {
     kws_search_t *kwss = (kws_search_t *) ckd_calloc(1, sizeof(*kwss));

--- a/src/kws_search.h
+++ b/src/kws_search.h
@@ -43,6 +43,9 @@
 #include <sphinxbase/glist.h>
 #include <sphinxbase/cmd_ln.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
 #include "pocketsphinx_internal.h"
 #include "kws_detections.h"
@@ -106,7 +109,7 @@ typedef struct kws_search_s {
 ps_search_t *kws_search_init(const char *name,
 			     const char *keyphrase,
 			     const char *keyfile,
-                             cmd_ln_t * config,
+                             ps_config_t * config,
                              acmod_t * acmod,
                              dict_t * dict, dict2pid_t * d2p);
 

--- a/src/ms_gauden.c
+++ b/src/ms_gauden.c
@@ -508,7 +508,7 @@ gauden_dist(gauden_t * g,
 }
 
 int32
-gauden_mllr_transform(gauden_t *g, ps_mllr_t *mllr, cmd_ln_t *config)
+gauden_mllr_transform(gauden_t *g, ps_mllr_t *mllr, ps_config_t *config)
 {
     int32 i, m, f, d, *flen;
 

--- a/src/ms_gauden.h
+++ b/src/ms_gauden.h
@@ -55,6 +55,9 @@
 #include <sphinxbase/logmath.h>
 #include <sphinxbase/cmd_ln.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
 #include "vector.h"
 #include "pocketsphinx_internal.h"
@@ -112,7 +115,7 @@ gauden_init (char const *meanfile,/**< Input: File containing means of mixture g
 void gauden_free(gauden_t *g); /**< In: The gauden_t to free */
 
 /** Transform Gaussians according to an MLLR matrix (or, eventually, more). */
-int32 gauden_mllr_transform(gauden_t *s, ps_mllr_t *mllr, cmd_ln_t *config);
+int32 gauden_mllr_transform(gauden_t *s, ps_mllr_t *mllr, ps_config_t *config);
 
 /**
  * Compute gaussian density values for the given input observation vector wrt the

--- a/src/pocketsphinx.c
+++ b/src/pocketsphinx.c
@@ -194,7 +194,7 @@ ps_default_modeldir(void)
 
 /* Set default acoustic and language models if they are not defined in configuration. */
 void
-ps_default_search_args(cmd_ln_t *config)
+ps_default_search_args(ps_config_t *config)
 {
 #ifdef MODELDIR
     const char *hmmdir = cmd_ln_str_r(config, "-hmm");
@@ -231,7 +231,7 @@ ps_default_search_args(cmd_ln_t *config)
 }
 
 int
-ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config)
+ps_reinit_feat(ps_decoder_t *ps, ps_config_t *config)
 {
     if (config && config != ps->config) {
         cmd_ln_free_r(ps->config);
@@ -241,7 +241,7 @@ ps_reinit_feat(ps_decoder_t *ps, cmd_ln_t *config)
 }
 
 int
-ps_reinit(ps_decoder_t *ps, cmd_ln_t *config)
+ps_reinit(ps_decoder_t *ps, ps_config_t *config)
 {
     const char *path;
     const char *keyphrase;
@@ -438,7 +438,7 @@ ps_set_cmn(ps_decoder_t *ps, const char *cmn)
 
 
 ps_decoder_t *
-ps_init(cmd_ln_t *config)
+ps_init(ps_config_t *config)
 {
     ps_decoder_t *ps;
     
@@ -483,7 +483,7 @@ ps_free(ps_decoder_t *ps)
     return 0;
 }
 
-cmd_ln_t *
+ps_config_t *
 ps_get_config(ps_decoder_t *ps)
 {
     return ps->config;
@@ -820,7 +820,7 @@ ps_load_dict(ps_decoder_t *ps, char const *dictfile,
     dict2pid_t *d2p;
     dict_t *dict;
     hash_iter_t *search_it;
-    cmd_ln_t *newconfig;
+    ps_config_t *newconfig;
 
     (void)format;
     /* Create a new scratch config to load this dict (so existing one
@@ -1493,7 +1493,7 @@ void
 ps_search_init(ps_search_t *search, ps_searchfuncs_t *vt,
 	       const char *type,
 	       const char *name,
-               cmd_ln_t *config, acmod_t *acmod, dict_t *dict,
+               ps_config_t *config, acmod_t *acmod, dict_t *dict,
                dict2pid_t *d2p)
 {
     search->vt = vt;

--- a/src/pocketsphinx_internal.h
+++ b/src/pocketsphinx_internal.h
@@ -52,8 +52,10 @@
 #include <sphinxbase/logmath.h>
 #include <sphinxbase/profile.h>
 
+/* Public headers. */
+#include <pocketsphinx.h>
+
 /* Local headers. */
-#include "pocketsphinx.h"
 #include "acmod.h"
 #include "dict.h"
 #include "dict2pid.h"


### PR DESCRIPTION
For the moment we just rename cmd_ln_t and make a macro to simplify its use, but this will be improved.