### PR TITLE
Fix float-to-int underflows (#199, #252)

### DIFF
--- a/src/allphone_search.c
+++ b/src/allphone_search.c
@@ -798,7 +798,7 @@ allphone_backtrace(allphone_search_t * allphs, int32 f, int32 *out_score)
         return;
 
     /* Find bestscore */
-    best = (int32) 0x80000000;
+    best = MAX_NEG_INT32;
     best_idx = -1;
     while (frm == last_frm && hist_idx > 0) {
         h = blkarray_list_get(allphs->history, hist_idx);

--- a/src/ms_gauden.c
+++ b/src/ms_gauden.c
@@ -53,7 +53,7 @@
 #define M_PI	3.1415926535897932385e0
 #endif
 
-#define WORST_DIST	(int32)(0x80000000)
+#define WORST_DIST	MAX_NEG_INT32
 
 void
 gauden_dump(const gauden_t * g)

--- a/src/ms_mgau.c
+++ b/src/ms_mgau.c
@@ -215,7 +215,7 @@ ms_cont_mgau_frame_eval(ps_mgau_t * mg,
 	for (gid = 0; gid < g->n_mgau; gid++)
 	    gauden_dist(g, gid, topn, feat, msg->dist[gid]);
 
-	best = (int32) 0x7fffffff;
+	best = MAX_INT32;
 	for (s = 0; (uint32)s < sen->n_sen; s++) {
 	    senscr[s] = senone_eval(sen, s, msg->dist[sen->mgau[s]], topn);
 	    if (best > senscr[s]) {
@@ -253,7 +253,7 @@ ms_cont_mgau_frame_eval(ps_mgau_t * mg,
 		gauden_dist(g, gid, topn, feat, msg->dist[gid]);
 	}
 
-	best = (int32) 0x7fffffff;
+	best = MAX_INT32;
 	n = 0;
 	for (i = 0; i < n_senone_active; i++) {
 	    int32 s = senone_active[i] + n;

--- a/src/ms_senone.c
+++ b/src/ms_senone.c
@@ -372,15 +372,20 @@ senone_eval(senone_t * s, int id, gauden_dist_t ** dist, int32 n_top)
     for (f = 0; (uint32)f < s->n_feat; f++) {
         fdist = dist[f];
 
-        /* FIXME: possible under/overflow!!! */
-	fden = ((int32)fdist[0].dist + ((1<<SENSCR_SHIFT) - 1)) >> SENSCR_SHIFT;
+        if (fdist[0].dist < (mfcc_t)MAX_NEG_INT32)
+            fden = MAX_NEG_INT32 >> SENSCR_SHIFT;
+        else
+            fden = ((int32)fdist[0].dist + ((1<<SENSCR_SHIFT) - 1)) >> SENSCR_SHIFT;
         fscr = (s->n_gauden > 1)
 	    ? (fden + -s->pdf[id][f][fdist[0].id])  /* untransposed */
 	    : (fden + -s->pdf[f][fdist[0].id][id]); /* transposed */
         /* Remaining of n_top codewords for feature f */
         for (t = 1; t < n_top; t++) {
-            /* FIXME: possible under/overflow!!! */
-	    fden = ((int32)fdist[t].dist + ((1<<SENSCR_SHIFT) - 1)) >> SENSCR_SHIFT;
+            if (fdist[t].dist < (mfcc_t)MAX_NEG_INT32)
+                fden = MAX_NEG_INT32 >> SENSCR_SHIFT;
+            else
+                fden = ((int32)fdist[t].dist + ((1<<SENSCR_SHIFT) - 1)) >> SENSCR_SHIFT;
+                
             fwscr = (s->n_gauden > 1) ?
                 (fden + -s->pdf[id][f][fdist[t].id]) :
                 (fden + -s->pdf[f][fdist[t].id][id]);

--- a/src/ms_senone.c
+++ b/src/ms_senone.c
@@ -372,12 +372,14 @@ senone_eval(senone_t * s, int id, gauden_dist_t ** dist, int32 n_top)
     for (f = 0; (uint32)f < s->n_feat; f++) {
         fdist = dist[f];
 
+        /* FIXME: possible under/overflow!!! */
 	fden = ((int32)fdist[0].dist + ((1<<SENSCR_SHIFT) - 1)) >> SENSCR_SHIFT;
         fscr = (s->n_gauden > 1)
 	    ? (fden + -s->pdf[id][f][fdist[0].id])  /* untransposed */
 	    : (fden + -s->pdf[f][fdist[0].id][id]); /* transposed */
         /* Remaining of n_top codewords for feature f */
         for (t = 1; t < n_top; t++) {
+            /* FIXME: possible under/overflow!!! */
 	    fden = ((int32)fdist[t].dist + ((1<<SENSCR_SHIFT) - 1)) >> SENSCR_SHIFT;
             fwscr = (s->n_gauden > 1) ?
                 (fden + -s->pdf[id][f][fdist[t].id]) :

--- a/src/ngram_search_fwdtree.c
+++ b/src/ngram_search_fwdtree.c
@@ -1196,7 +1196,7 @@ bptable_maxwpf(ngram_search_t *ngs, int frame_idx)
         return;
 
     /* Allow only one filler word exit (the best) per frame */
-    bestscr = (int32) 0x80000000;
+    bestscr = MAX_NEG_INT32;
     bestbpe = NULL;
     n = 0;
     for (bp = ngs->bp_table_idx[frame_idx]; bp < ngs->bpidx; bp++) {
@@ -1221,7 +1221,7 @@ bptable_maxwpf(ngram_search_t *ngs, int frame_idx)
          - ngs->bp_table_idx[frame_idx]) - n;  /* No. of entries after limiting fillers */
     for (; n > ngs->maxwpf; --n) {
         /* Find worst BPTable entry */
-        worstscr = (int32) 0x7fffffff;
+        worstscr = MAX_INT32;
         worstbpe = NULL;
         for (bp = ngs->bp_table_idx[frame_idx]; (bp < ngs->bpidx); bp++) {
             bpe = &(ngs->bp_table[bp]);
@@ -1334,7 +1334,7 @@ word_transition(ngram_search_t *ngs, int frame_idx)
      */
     for (i = 0; i < ngs->n_1ph_LMwords; i++) {
         w = ngs->single_phone_wid[i];
-        ngs->last_ltrans[w].dscr = (int32) 0x80000000;
+        ngs->last_ltrans[w].dscr = MAX_NEG_INT32;
     }
     for (bp = ngs->bp_table_idx[frame_idx]; bp < ngs->bpidx; bp++) {
         bpe = &(ngs->bp_table[bp]);

--- a/src/ps_lattice.c
+++ b/src/ps_lattice.c
@@ -575,6 +575,7 @@ ps_lattice_read(ps_decoder_t *ps,
         pd = darray[from];
         d = darray[to];
         if (logratio != 1.0f)
+            /* FIXME: possible under/overflow!!! */
             ascr = (int32)(ascr * logratio);
         ps_lattice_link(dag, pd, d, ascr, d->sf - 1);
     }
@@ -1372,6 +1373,7 @@ ps_lattice_bestpath(ps_lattice_t *dag, ngram_model_t *lmset,
         }
     }
     /* FIXME: floating point... */
+    /* FIXME: possible under/overflow!!! */
     dag->norm += (int32)(dag->final_node_ascr << SENSCR_SHIFT) * ascale;
 
     E_INFO("Bestpath score: %d\n", bestescr);

--- a/src/ptm_mgau.c
+++ b/src/ptm_mgau.c
@@ -126,7 +126,10 @@ eval_topn(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
             obs += 4;
             mean += 4;
         }
-        insertion_sort_topn(topn, i, (int32)d);
+        if (d < (mfcc_t)INT_MIN)  /* Redundant if FIXED_POINT */
+            insertion_sort_topn(topn, i, INT_MIN);
+        else
+            insertion_sort_topn(topn, i, (int32)d);
     }
 
     return topn[0].score;
@@ -213,7 +216,10 @@ eval_cb(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
         }
         if (i < s->max_topn)
             continue;       /* already there.  Don't insert */
-        insertion_sort_cb(&cur, worst, best, cw, (int32)d);
+        if (d < (mfcc_t)INT_MIN)  /* Redundant if FIXED_POINT */
+            insertion_sort_cb(&cur, worst, best, cw, INT_MIN);
+        else
+            insertion_sort_cb(&cur, worst, best, cw, (int32)d);
     }
 
     return best->score;
@@ -271,7 +277,6 @@ ptm_mgau_codebook_norm(ptm_mgau_t *s, mfcc_t **z, int frame)
             if (norm < s->f->topn[i][j][0].score >> SENSCR_SHIFT)
                 norm = s->f->topn[i][j][0].score >> SENSCR_SHIFT;
         }
-        assert(norm != WORST_SCORE);
         for (i = 0; i < s->g->n_mgau; ++i) {
             int32 k;
             if (bitvec_is_clear(s->f->mgau_active, i))

--- a/src/ptm_mgau.c
+++ b/src/ptm_mgau.c
@@ -126,8 +126,8 @@ eval_topn(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
             obs += 4;
             mean += 4;
         }
-        if (d < (mfcc_t)INT_MIN)  /* Redundant if FIXED_POINT */
-            insertion_sort_topn(topn, i, INT_MIN);
+        if (d < (mfcc_t)MAX_NEG_INT32)  /* Redundant if FIXED_POINT */
+            insertion_sort_topn(topn, i, MAX_NEG_INT32);
         else
             insertion_sort_topn(topn, i, (int32)d);
     }
@@ -216,8 +216,8 @@ eval_cb(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
         }
         if (i < s->max_topn)
             continue;       /* already there.  Don't insert */
-        if (d < (mfcc_t)INT_MIN)  /* Redundant if FIXED_POINT */
-            insertion_sort_cb(&cur, worst, best, cw, INT_MIN);
+        if (d < (mfcc_t)MAX_NEG_INT32)  /* Redundant if FIXED_POINT */
+            insertion_sort_cb(&cur, worst, best, cw, MAX_NEG_INT32);
         else
             insertion_sort_cb(&cur, worst, best, cw, (int32)d);
     }

--- a/src/tied_mgau_common.h
+++ b/src/tied_mgau_common.h
@@ -57,7 +57,7 @@ extern "C" {
 #define MGAU_MIXW_VERSION	"1.0"   /* Sphinx-3 file format version for mixw */
 #define MGAU_PARAM_VERSION	"1.0"   /* Sphinx-3 file format version for mean/var */
 #define NONE		-1
-#define WORST_DIST	(int32)(0x80000000)
+#define WORST_DIST	MAX_NEG_INT32
 
 /** Subtract GMM component b (assumed to be positive) and saturate */
 #ifdef FIXED_POINT

--- a/test/unit/test_ngram_model_read.c
+++ b/test/unit/test_ngram_model_read.c
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
                     "hmm: \"" MODELDIR "/en-us/en-us\","
                     "lm: \"" MODELDIR "/en-us/en-us.lm.bin\","
                     "dict: \"" DATADIR "/defective.dic\","
-                    "dictcase: true,"
+                    "dictcase: true, loglevel: INFO, bestpath: false, fwdflat: false,"
                     "samprate: 16000"));
     TEST_ASSERT(ps = ps_init(config));
     TEST_ASSERT(rawfh = fopen(DATADIR "/goforward.raw", "rb"));


### PR DESCRIPTION
IIRC float to integer conversion is somewhat underspecified in IEEE754, and MIPS and other architectures do different things, leading to unpredictable (and bad) decoding results.

In any case we shouldn't be underflowing in the first place!!

This should fix that everywhere, and also clarifies some magic constants to be less magic.