### PR TITLE
Disallow multiple search types in config or command-line

### DIFF
--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -145,6 +145,16 @@ POCKETSPHINX_EXPORT
 int ps_config_free(ps_config_t *config);
 
 /**
+ * Validate configuration.
+ *
+ * Currently this just checks that you haven't specified multiple
+ * types of grammars or language models at the same time.
+ *
+ * @return 0 for success, <0 for failure.
+ */
+int ps_config_validate(ps_config_t *config);
+
+/**
  * Create or update a configuration by parsing slightly extended JSON.
  *
  * This function parses a JSON object in non-strict mode to produce a

--- a/src/ps_config.c
+++ b/src/ps_config.c
@@ -122,6 +122,46 @@ ps_config_free(ps_config_t *config)
     return 0;
 }
 
+static const char *searches[] = {
+    "lm",
+    "jsgf",
+    "fsg",
+    "keyphrase",
+    "kws",
+    "allphone",
+    "lmctl"
+};
+static const int nsearches = sizeof(searches)/sizeof(searches[0]);
+    
+int
+ps_config_validate(ps_config_t *config)
+{
+    int i, found = 0;
+    for (i = 0; i < nsearches; ++i) {
+        if (ps_config_str(config, searches[i]) != NULL)
+            if (++found > 1)
+                break;
+    }
+    if (found > 1) {
+        int len = strlen("Only one of ");
+        char *msg;
+        for (i = 0; i < nsearches; ++i)
+            len += strlen(searches[i]) + 2;
+        len += strlen("can be enabled at a time in config\n");
+        msg = ckd_malloc(len + 1);
+        strcpy(msg, "Only one of ");
+        for (i = 0; i < nsearches; ++i) {
+            strcat(msg, searches[i]);
+            strcat(msg, ", ");
+        }
+        strcat(msg, "can be enabled at a time in config\n");
+        E_ERROR(msg);
+        ckd_free(msg);
+        return -1;
+    }
+    return 0;
+}
+
 void
 json_error(int err)
 {

--- a/test/unit/test_config.c
+++ b/test/unit/test_config.c
@@ -129,6 +129,62 @@ test_config_json(void)
     ckd_free(json);
 }
 
+static void
+test_validate_config(void)
+{
+    ps_config_t *config;
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "lm: \"" MODELDIR "/en-us/en-us.lm.bin\","
+                    "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\","
+                    "fwdtree: true,"
+                    "fwdflat: false,"
+                    "bestpath: false,"
+                    "samprate: 16000"));
+    TEST_EQUAL(0, ps_config_validate(config));
+    ps_config_free(config);
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "lm: \"" MODELDIR "/en-us/en-us.lm.bin\","
+                    "jsgf: \"" DATADIR "/goforward.gram\","
+                    "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\","
+                    "fwdtree: true,"
+                    "fwdflat: false,"
+                    "bestpath: false,"
+                    "samprate: 16000"));
+    TEST_ASSERT(ps_config_validate(config) < 0);
+    ps_config_free(config);
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "kws: \"" DATADIR "/goforward.kws\","
+                    "jsgf: \"" DATADIR "/goforward.gram\","
+                    "fsg: \"" DATADIR "/goforward.fsg\","
+                    "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\","
+                    "fwdtree: true,"
+                    "fwdflat: false,"
+                    "bestpath: false,"
+                    "samprate: 16000"));
+    TEST_ASSERT(ps_config_validate(config) < 0);
+    ps_config_free(config);
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "keyphrase: \"bonjour alexis\","
+                    "fwdtree: true,"
+                    "fwdflat: false,"
+                    "bestpath: false,"
+                    "samprate: 16000"));
+    TEST_EQUAL(0, ps_config_validate(config));
+    ps_config_free(config);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -137,6 +193,7 @@ main(int argc, char *argv[])
     test_config_init();
     test_config_args();
     test_config_json();
+    test_validate_config();
     
     return 0;
 }


### PR DESCRIPTION
Python API does some helpful things to avoid surprises.