### PR TITLE
Make seg_iter and hyp behave as expected in kws search (fixes #122)

### DIFF
--- a/cython/test/config_test.py
+++ b/cython/test/config_test.py
@@ -124,6 +124,7 @@ class TestConfigIter(unittest.TestCase):
         self.assertEqual(default_len, len(config))
         config["hmm"] = os.path.join(MODELDIR, "en-us", "en-us")
         config["fsg"] = os.path.join(DATADIR, "goforward.fsg")
+        config["lm"] = None  # It won't do this automatically
         config["dict"] = os.path.join(DATADIR, "turtle.dic")
         self.assertEqual(default_len, len(config))
         for key in config:

--- a/src/kws_detections.c
+++ b/src/kws_detections.c
@@ -102,6 +102,7 @@ kws_detections_hyp_str(kws_detections_t *detections, int frame, int delay)
 
     hyp_str = (char *)ckd_calloc(len, sizeof(char));
     c = hyp_str;
+    detections->detect_list = glist_reverse(detections->detect_list);
     for (gn = detections->detect_list; gn; gn = gnode_next(gn)) {
 	kws_detection_t *det = (kws_detection_t *)gnode_ptr(gn);
 	if (det->ef < frame - delay) {
@@ -115,6 +116,7 @@ kws_detections_hyp_str(kws_detections_t *detections, int frame, int delay)
         c--;
 	*c = '\0';
     }
+    detections->detect_list = glist_reverse(detections->detect_list);
     return hyp_str;
 }
 

--- a/src/kws_search.h
+++ b/src/kws_search.h
@@ -57,9 +57,11 @@ extern "C" {
  * Segmentation "iterator" for KWS history.
  */
 typedef struct kws_seg_s {
-    ps_seg_t base;       /**< Base structure. */
-    gnode_t *detection;  /**< Keyphrase detection correspondent to segment. */
-    frame_idx_t last_frame; /**< Last frame to raise the detection */
+    ps_seg_t base;                /**< Base structure. */
+    kws_detection_t **detections; /**< Vector of current detections. */
+    frame_idx_t last_frame;       /**< Last frame to raise the detection. */
+    int n_detections;             /**< Size of vector. */
+    int pos;                      /**< Position of iterator. */
 } kws_seg_t;
 
 typedef struct kws_keyphrase_s {

--- a/test/data/goforward.kws
+++ b/test/data/goforward.kws
@@ -3,6 +3,7 @@ something
 bad line / here
 just bad line /
 forward
+meters
 
 non_existign_word
 

--- a/test/unit/test_keyphrase.c
+++ b/test/unit/test_keyphrase.c
@@ -19,5 +19,5 @@ main(int argc, char *argv[])
                     "hmm: \"" MODELDIR "/en-us/en-us\","
                     "kws: \"" DATADIR "/goforward.kws\","
                     "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\""));
-    return ps_decoder_test(config, "KEYPHRASE", "forward");
+    return ps_decoder_test(config, "KEYPHRASE", "forward meters");
 }


### PR DESCRIPTION
While it's true that kws search is not necessarily intended to give you more than one detected keyword at a time, if you are using it to spot phrases in a pre-existing file, you might like to have them in the order they were spoken, rather than backwards.