### PR TITLE
Add missing close brace for C++

### DIFF
--- a/include/pocketsphinx/model.h
+++ b/include/pocketsphinx/model.h
@@ -1044,4 +1044,8 @@ int32 ngram_model_set_known_wid(ngram_model_t *set, int32 set_wid);
 POCKETSPHINX_EXPORT
 void ngram_model_flush(ngram_model_t *lm);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __PS_MODEL_H__ */


### PR DESCRIPTION
Does not compile when included from .cpp file because of missing closing brace.