### PR TITLE
Use a separate search for ps_set_align_text()

### DIFF
--- a/cython/test/alignment_test.py
+++ b/cython/test/alignment_test.py
@@ -33,6 +33,18 @@ class TestAlignment(unittest.TestCase):
                 for state in phone:
                     print("\t\t", state.start, state.duration, state.score, state.name)
 
+    def test_default_lm(self):
+        decoder = Decoder()
+        self.assertEqual(decoder.current_search(), "_default")
+        decoder.set_align_text("go forward then meters")
+        self.assertEqual(decoder.current_search(), "_align")
+        self._run_decode(decoder)
+        self.assertEqual(decoder.hyp().hypstr, "go forward then meters")
+        decoder.activate_search()
+        self.assertEqual(decoder.current_search(), "_default")
+        self._run_decode(decoder)
+        self.assertEqual(decoder.hyp().hypstr, "go forward ten meters")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/include/pocketsphinx/search.h
+++ b/include/pocketsphinx/search.h
@@ -326,7 +326,9 @@ int ps_add_allphone_file(ps_decoder_t *ps, const char *name, const char *path);
  * Unlike the `ps_add_*` functions, this activates the search module
  * immediately, since force-alignment is nearly always a single shot.
  * Currently "under the hood" this is an FSG search but you shouldn't
- * depend on that.
+ * depend on that.  The search module activated is *not* the default
+ * search, so you can return to that one by calling ps_activate_search
+ * with `NULL`.
  *
  * Decoding proceeds as normal, though only this word sequence will be
  * recognized, with silences and alternate pronunciations inserted.

--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -552,12 +552,7 @@ bin_mdef_write(bin_mdef_t * m, const char *filename)
     fwrite(&m->n_sseq, 4, 1, fh);
     fwrite(&m->n_ctx, 4, 1, fh);
     fwrite(&m->n_cd_tree, 4, 1, fh);
-    /* Write this as a 32-bit value to preserve alignment for the
-     * non-mmap case (we want things aligned both from the
-     * beginning of the file and the beginning of the phone
-     * strings). */
-    val = m->sil;
-    fwrite(&val, 4, 1, fh);
+    fwrite(&m->sil, 4, 1, fh);
 
     /* Phone strings. */
     for (i = 0; i < m->n_ciphone; ++i)
@@ -581,6 +576,7 @@ bin_mdef_write(bin_mdef_t * m, const char *filename)
                m->n_sseq * m->n_emit_state, fh);
     }
     else {
+        /* FIXME: This code is never used */
         int32 n;
 
         /* Calculate size of sseq */

--- a/src/pocketsphinx.c
+++ b/src/pocketsphinx.c
@@ -722,13 +722,12 @@ ps_set_align_text(ps_decoder_t *ps, const char *text)
     ckd_free(textbuf);
     fsg->start_state = 0;
     fsg->final_state = nwords;
-    if (ps_add_fsg(ps, PS_DEFAULT_SEARCH, fsg) < 0) {
+    if (ps_add_fsg(ps, PS_DEFAULT_ALIGN_SEARCH, fsg) < 0) {
         fsg_model_free(fsg);
         return -1;
     }
-    /* FIXME: Should rethink ownership semantics, this is annoying. */
     fsg_model_free(fsg);
-    return ps_activate_search(ps, PS_DEFAULT_SEARCH);
+    return ps_activate_search(ps, PS_DEFAULT_ALIGN_SEARCH);
 }
 
 int

--- a/src/pocketsphinx_internal.h
+++ b/src/pocketsphinx_internal.h
@@ -69,6 +69,7 @@ typedef struct ps_search_s ps_search_t;
 
 /* Search names*/
 #define PS_DEFAULT_SEARCH  "_default"
+#define PS_DEFAULT_ALIGN_SEARCH  "_align"
 #define PS_DEFAULT_PL_SEARCH  "_default_pl"
 
 /* Search types */


### PR DESCRIPTION
This clears up some undefined behaviour, the user may expect to be
able to restore the orginal LM (or FSG, or KWS, or whatever) after
calling ps_set_align_text() but that was not possible
