### PR TITLE
Removed unnecessary libpthread in package config

### DIFF
--- a/pocketsphinx.pc.in
+++ b/pocketsphinx.pc.in
@@ -11,5 +11,5 @@ Description: Lightweight speech recognition system
 Version: @PROJECT_VERSION@
 URL: @PACKAGE_URL@
 Libs: -L${libdir} -lpocketsphinx
-Libs.private: ${libs} -lm -lpthread
+Libs.private: ${libs} -lm
 Cflags: -I${includedir} -I${includedir}/sphinxbase -I${includedir}/pocketsphinx


### PR DESCRIPTION
Assuming there was an attempt to use pthread, the current version of PocketSphinx does not rely on pthread.
Therefore, unnecessary libpthread has been removed from the pkg-config include file to avoid any misunderstanding.