### PR TITLE
Removed unnecessary shinxbase in package config

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ other people contributed as well, see [the AUTHORS file](./AUTHORS)
 for more details.
 
 David Huggins-Daines (the author of this document) is
-guilty^H^H^H^H^Hresponsible for creating `PocketSphinx` which added
+responsible for creating `PocketSphinx` which added
 various speed and memory optimizations, fixed-point computation, JSGF
 support, portability to various platforms, and a somewhat coherent
 API.  He then disappeared for a while.

--- a/pocketsphinx.pc.in
+++ b/pocketsphinx.pc.in
@@ -12,4 +12,4 @@ Version: @PROJECT_VERSION@
 URL: @PACKAGE_URL@
 Libs: -L${libdir} -lpocketsphinx
 Libs.private: ${libs} -lm
-Cflags: -I${includedir} -I${includedir}/sphinxbase -I${includedir}/pocketsphinx
+Cflags: -I${includedir} -I${includedir}/pocketsphinx


### PR DESCRIPTION
SphinxBase is still included in package config file.
Removed it.