### PR TITLE
Require specific setuptools version to fix editable install (fixes: #353)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,3 +46,16 @@ jobs:
           pip install .
       - name: Run tests
         run: pytest
+  pytest-editable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        run: |
+          sudo apt-get install sox
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
          "wheel",
-         "setuptools>=45",
+         "setuptools>=45,<64",
      	 "scikit-build~=0.15",
 	 "Cython",
          "cmake",


### PR DESCRIPTION
There is a very long saga in the `scikit-build` issues about this, which I haven't read, but did read enough to know that `setuptools>=64` breaks `pip install -e`.

So make sure to use `setuptools<64`.

See: https://github.com/scikit-build/scikit-build/issues/981
