### PR TITLE
Add prerequisite packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python3 -m venv ~/ve_pocketsphinx
 . ~/ve_pocketsphinx/bin/activate
 pip install .
 ```
-Install two prerequisites particular to RaspberryOS:
+Install prerequisite packages particular to RaspberryOS:
 
 ```
 sudo apt install libpulse-dev libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 ffmpeg

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ python3 -m venv ~/ve_pocketsphinx
 . ~/ve_pocketsphinx/bin/activate
 pip install .
 ```
+Install two prerequisites particular to RaspberryOS:
+
+```
+sudo apt install libpulse-dev libasound-dev portaudio19-dev libportaudio2 libportaudiocpp0 ffmpeg libav-tools
+```
 
 To install the C library and bindings (assuming you have access to
 /usr/local - if not, use `-DCMAKE_INSTALL_PREFIX` to set a different

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install .
 Install two prerequisites particular to RaspberryOS:
 
 ```
-sudo apt install libpulse-dev libasound-dev portaudio19-dev libportaudio2 libportaudiocpp0 ffmpeg libav-tools
+sudo apt install libpulse-dev libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 ffmpeg
 ```
 
 To install the C library and bindings (assuming you have access to


### PR DESCRIPTION
While building for RaspberryPi OS, a set of packages were recommended during the process. This change request adds the packages by name, relative to Debian Bookworm.