### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,7 +19,7 @@ Improvements:
 
 Fixes:
  * Memory leaks, refcounting and other memory-related issues
- * Use proper word bounary senones for the words added on the fly
+ * Use proper word boundary senones for the words added on the fly
  * Accurate FSG lextree construction
 
 Pocketsphinx 0.7
@@ -48,7 +48,7 @@ Bug fixes:
  * Fixes very important regression with NULL transitions in fsg search
  * Proper acoustic score scaling during posterior calculation.
  
-And many, many, many more intersting things!
+And many, many, many more interesting things!
 
 Pocketsphinx pre
 ^^^^^^^^^^^^^^^^

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Usage
 -----
 
 The `pocketsphinx` command-line program reads single-channel 16-bit
-PCM audio from standard input or one or more files, and attemps to
+PCM audio from standard input or one or more files, and attempts to
 recognize speech in it using the default acoustic and language model.
 It accepts a large number of options which you probably don't care
 about, a *command* which defaults to `live`, and one or more inputs

--- a/cython/_pocketsphinx.pyx
+++ b/cython/_pocketsphinx.pyx
@@ -1757,7 +1757,7 @@ cdef class Vad:
     """Voice activity detection class.
 
     Args:
-      mode(int): Aggressiveness of voice activity detction (0-3)
+      mode(int): Aggressiveness of voice activity detection (0-3)
       sample_rate(int): Sampling rate of input, default is 16000.
                         Rates other than 8000, 16000, 32000, 48000
                         are only approximately supported, see note
@@ -1841,7 +1841,7 @@ cdef class Endpointer:
       window(float): Length in seconds of window for decision.
       ratio(float): Fraction of window that must be speech or
                     non-speech to make a transition.
-      mode(int): Aggressiveness of voice activity detction (0-3)
+      mode(int): Aggressiveness of voice activity detection (0-3)
       sample_rate(int): Sampling rate of input, default is 16000.
                         Rates other than 8000, 16000, 32000, 48000
                         are only approximately supported, see note

--- a/cython/pocketsphinx/segmenter.py
+++ b/cython/pocketsphinx/segmenter.py
@@ -31,7 +31,7 @@ class Segmenter(Endpointer):
       window(float): Length in seconds of window for decision.
       ratio(float): Fraction of window that must be speech or
                     non-speech to make a transition.
-      mode(int): Aggressiveness of voice activity detction (0-3)
+      mode(int): Aggressiveness of voice activity detection (0-3)
       sample_rate(int): Sampling rate of input, default is 16000.
                         Rates other than 8000, 16000, 32000, 48000
                         are only approximately supported, see note

--- a/doxygen/pocketsphinx.1
+++ b/doxygen/pocketsphinx.1
@@ -13,7 +13,7 @@ pocketsphinx \- Run speech recognition on audio data
 .PP
 The ‘\f[CR]pocketsphinx\fP’ command-line program reads single-channel
 16-bit PCM audio one or more input files (or ‘\f[CR]-\fP’ to read from
-standard input), and attemps to recognize speech in it using the
+standard input), and attempts to recognize speech in it using the
 default acoustic and language model. The input files can be raw audio,
 WAV, or NIST Sphere files, though some of these may not be recognized
 properly.  It accepts a large number of options which you probably

--- a/doxygen/pocketsphinx.1.in
+++ b/doxygen/pocketsphinx.1.in
@@ -13,7 +13,7 @@ pocketsphinx \- Run speech recognition on audio data
 .PP
 The ‘\f[CR]pocketsphinx\fP’ command-line program reads single-channel
 16-bit PCM audio one or more input files (or ‘\f[CR]-\fP’ to read from
-standard input), and attemps to recognize speech in it using the
+standard input), and attempts to recognize speech in it using the
 default acoustic and language model. The input files can be raw audio,
 WAV, or NIST Sphere files, though some of these may not be recognized
 properly.  It accepts a large number of options which you probably

--- a/gst/gstpocketsphinx.c
+++ b/gst/gstpocketsphinx.c
@@ -40,7 +40,7 @@
 /**
  * SECTION:element-pocketsphix
  *
- * The element runs the speech recohgnition on incomming audio buffers and
+ * The element runs the speech recohgnition on incoming audio buffers and
  * generates an element messages named <classname>&quot;pocketsphinx&quot;</classname>
  * for each hypothesis and one for the final result. The message's structure 
  * contains these fields:
@@ -252,8 +252,8 @@ gst_pocketsphinx_class_init(GstPocketSphinxClass * klass)
                              G_PARAM_READWRITE));
     g_object_class_install_property
         (gobject_class, PROP_JSGF_FILE,
-         g_param_spec_string("jsgf", "Grammer file",
-                             "File with grammer in Java Speech Grammar Format (JSGF)",
+         g_param_spec_string("jsgf", "Grammar file",
+                             "File with grammar in Java Speech Grammar Format (JSGF)",
                              NULL,
                              G_PARAM_READWRITE));
     g_object_class_install_property

--- a/include/pocketsphinx/alignment.h
+++ b/include/pocketsphinx/alignment.h
@@ -74,7 +74,7 @@ typedef struct ps_alignment_s ps_alignment_t;
 typedef struct ps_alignment_iter_s ps_alignment_iter_t;
 
 /**
- * Retain an alighment
+ * Retain an alignment
  * @memberof ps_alignment_t
  */
 POCKETSPHINX_EXPORT
@@ -120,7 +120,7 @@ POCKETSPHINX_EXPORT
 const char *ps_alignment_iter_name(ps_alignment_iter_t *itor);
 
 /**
- * Get the timing and score information for the current segment of an aligment.
+ * Get the timing and score information for the current segment of an alignment.
  *
  * @memberof ps_alignment_iter_t
  * @arg start Output pointer for start frame

--- a/include/pocketsphinx/err.h
+++ b/include/pocketsphinx/err.h
@@ -49,7 +49,7 @@
  * @file err.h
  * @brief Implementation of logging routines.
  *
- * Logging, warning, debug and error message output funtionality is provided in this file.
+ * Logging, warning, debug and error message output functionality is provided in this file.
  * Sphinxbase defines several level of logging messages - INFO, WARNING, ERROR, FATAL. By
  * default output goes to standard error output.
  *

--- a/include/pocketsphinx/model.h
+++ b/include/pocketsphinx/model.h
@@ -908,7 +908,7 @@ POCKETSPHINX_EXPORT
 ngram_model_set_iter_t *ngram_model_set_iter_next(ngram_model_set_iter_t *itor);
 
 /**
- * Finish iteration over a langauge model set.
+ * Finish iteration over a language model set.
  * @memberof ngram_model_set_iter_t
  */
 POCKETSPHINX_EXPORT

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -715,7 +715,7 @@ acmod_process_cep(acmod_t *acmod,
     }
 
 
-    /* FIXME: we can't split the last frame drop properly to be on the bounary, so just return */
+    /* FIXME: we can't split the last frame drop properly to be on the boundary, so just return */
     if (inptr + nfeat > acmod->n_feat_alloc && acmod->state == ACMOD_ENDED) {
 	*inout_n_frames -= ncep;
 	*inout_cep += ncep;

--- a/src/common_audio/signal_processing/include/signal_processing_library.h
+++ b/src/common_audio/signal_processing/include/signal_processing_library.h
@@ -48,7 +48,7 @@
 #define WEBRTC_SPL_MUL_16_U16(a, b) ((int32_t)(int16_t)(a) * (uint16_t)(b))
 
 // clang-format off
-// clang-format would choose some identation
+// clang-format would choose some indentation
 // leading to presubmit error (cpplint.py)
 #ifndef WEBRTC_ARCH_ARM_V7
 // For ARMv7 platforms, these are inline functions in spl_inl_armv7.h
@@ -242,7 +242,7 @@ int32_t WebRtcSpl_MinValueW32_mips(const int32_t* vector, size_t length);
 // Input:
 //      - vector : 16-bit input vector.
 //      - length : Number of samples in vector.
-// Ouput:
+// Output:
 //      - max_val : Maximum sample value in `vector`.
 //      - min_val : Minimum sample value in `vector`.
 void WebRtcSpl_MinMaxW16(const int16_t* vector,
@@ -305,7 +305,7 @@ size_t WebRtcSpl_MaxIndexW32(const int32_t* vector, size_t length);
 //      - vector : 16-bit input vector.
 //      - length : Number of samples in vector.
 //
-// Return value  : Index to the mimimum value in vector  (if multiple
+// Return value  : Index to the minimum value in vector  (if multiple
 //                 indexes have the minimum, return the first).
 size_t WebRtcSpl_MinIndexW16(const int16_t* vector, size_t length);
 
@@ -315,7 +315,7 @@ size_t WebRtcSpl_MinIndexW16(const int16_t* vector, size_t length);
 //      - vector : 32-bit input vector.
 //      - length : Number of samples in vector.
 //
-// Return value  : Index to the mimimum value in vector  (if multiple
+// Return value  : Index to the minimum value in vector  (if multiple
 //                 indexes have the minimum, return the first).
 size_t WebRtcSpl_MinIndexW32(const int32_t* vector, size_t length);
 

--- a/src/common_audio/signal_processing/min_max_operations.c
+++ b/src/common_audio/signal_processing/min_max_operations.c
@@ -136,7 +136,7 @@ int32_t WebRtcSpl_MinValueW32C(const int32_t* vector, size_t length) {
 
 // Index of maximum absolute value in a word16 vector.
 size_t WebRtcSpl_MaxAbsIndexW16(const int16_t* vector, size_t length) {
-  // Use type int for local variables, to accomodate the value of abs(-32768).
+  // Use type int for local variables, to accommodate the value of abs(-32768).
 
   size_t i = 0, index = 0;
   int absolute = 0, maximum = 0;

--- a/src/fe/fe_interface.c
+++ b/src/fe/fe_interface.c
@@ -489,7 +489,7 @@ fe_process_frames_int16(fe_t *fe,
         }
     }
 
-    /* Finally update the frame counter with the number of frames we procesed. */
+    /* Finally update the frame counter with the number of frames we processed. */
     *inout_nframes = outidx; /* FIXME: Not sure why I wrote it this way... */
     return 0;
 }

--- a/src/fe/fe_noise.c
+++ b/src/fe/fe_noise.c
@@ -36,7 +36,7 @@
  */
 
 /* This noise removal algorithm is inspired by the following papers
- * Computationally Efficient Speech Enchancement by Spectral Minina Tracking
+ * Computationally Efficient Speech Enhancement by Spectral Minina Tracking
  * by G. Doblinger
  *
  * Power-Normalized Cepstral Coefficients (PNCC) for Robust Speech Recognition
@@ -61,7 +61,7 @@
 #include "fe/fe_noise.h"
 #include "fe/fe_internal.h"
 
-/* Noise supression constants */
+/* Noise suppression constants */
 #define SMOOTH_WINDOW 4
 #define LAMBDA_POWER 0.7
 #define LAMBDA_A 0.995

--- a/src/fe/yin.c
+++ b/src/fe/yin.c
@@ -80,7 +80,7 @@ cmn_diff(int16 const *signal, int32 *out_diff, int ndiff)
     for (tscale = 0; tscale < 32; ++tscale)
         if (ndiff & (1<<(31-tscale)))
             break;
-    --tscale; /* Avoid teh overflowz. */
+    --tscale; /* Avoid the overflowz. */
     /* printf("tscale is %d (ndiff - 1) << tscale is %d\n",
        tscale, (ndiff-1) << tscale); */
 
@@ -226,7 +226,7 @@ yin_read(yin_t *pe, uint16 *out_period, uint16 *out_bestdiff)
 
     half_wsize = (pe->wsize-1)/2;
     /* Without any smoothing, just return the current value (don't
-     * need to do anything to the current poitner either). */
+     * need to do anything to the current pointer either). */
     if (half_wsize == 0) {
         if (pe->endut)
             return 0;

--- a/src/fe/yin.h
+++ b/src/fe/yin.h
@@ -102,7 +102,7 @@ void yin_write(yin_t *pe, int16 const *frame);
  *                     associated with <code>*out_pitch</code>, in Q15
  *                     format (i.e. scaled by 32768).  This can be
  *                     interpreted as one minus the probability of voicing.
- * @return Non-zero if enough data was avaliable to return a pitch
+ * @return Non-zero if enough data was available to return a pitch
  *         estimate, zero otherwise.
  */
 POCKETSPHINX_EXPORT

--- a/src/feat/cmn.h
+++ b/src/feat/cmn.h
@@ -57,7 +57,7 @@
  * Merged from the branch SPHINX3_5_2_RCI_IRII_BRANCH: Put data structure into the cmn_t structure.
  *
  * Revision 1.11.4.2  2005/10/17 04:45:57  arthchan2003
- * Free stuffs in cmn and feat corectly.
+ * Free stuffs in cmn and feat correctly.
  *
  * Revision 1.11.4.1  2005/07/05 06:25:08  arthchan2003
  * Fixed dox-doc.

--- a/src/feat/feat.c
+++ b/src/feat/feat.c
@@ -50,7 +50,7 @@
  * Merged from branch SPHINX3_5_2_RCI_IRII_BRANCH: a, Free buffers correctly. b, Fixed dox-doc.
  * 
  * Revision 1.21.4.3  2005/10/17 04:45:57  arthchan2003
- * Free stuffs in cmn and feat corectly.
+ * Free stuffs in cmn and feat correctly.
  *
  * Revision 1.21.4.2  2005/09/26 02:19:57  arthchan2003
  * Add message to show the directory which the feature is searched for.

--- a/src/feat/feat.h
+++ b/src/feat/feat.h
@@ -409,7 +409,7 @@ int32 feat_s2mfc2feat_live(feat_t  *fcb,     /**< In: Descriptor from feat_init(
                            mfcc_t **uttcep,  /**< In: Incoming cepstral buffer */
                            int32 *inout_ncep,/**< In: Size of incoming buffer.
                                                 Out: Number of incoming frames consumed. */
-                           int32 beginutt,   /**< In: Begining of utterance flag */
+                           int32 beginutt,   /**< In: Beginning of utterance flag */
                            int32 endutt,     /**< In: End of utterance flag */
                            mfcc_t ***ofeat   /**< In: Output feature buffer.  See
                                                 <strong>VERY IMPORTANT</strong> note

--- a/src/fsg_history.h
+++ b/src/fsg_history.h
@@ -191,7 +191,7 @@ void fsg_history_entry_add (fsg_history_t *h,
 void fsg_history_end_frame (fsg_history_t *h);
 
 
-/* Clear the hitory table */
+/* Clear the history table */
 void fsg_history_reset (fsg_history_t *h);
 
 

--- a/src/lm/bitarr.h
+++ b/src/lm/bitarr.h
@@ -125,13 +125,13 @@ void bitarr_write_int25(bitarr_address_t address, uint8 length, uint32 value);
 /**
  * Fills mask for certain int range according to provided max value
  * @param bit_mask mask that is filled
- * @param max_value bigest integer that is going to be stored using this mask
+ * @param max_value biggest integer that is going to be stored using this mask
  */
 void bitarr_mask_from_max(bitarr_mask_t *bit_mask, uint32 max_value);
 
 /**
  * Computes amount of bits required ti store integers upto value provided.
- * @param max_value bigest integer that going to be stored using this amount of bits
+ * @param max_value biggest integer that going to be stored using this amount of bits
  * @return amount of bits required to store integers from range with maximum provided
  */
 uint8 bitarr_required_bits(uint32 max_value);

--- a/src/lm/ngrams_raw.h
+++ b/src/lm/ngrams_raw.h
@@ -64,7 +64,7 @@ int ngram_ord_comparator(const void *a_raw, const void *b_raw);
  * Read ngrams of order > 1 from ARPA file
  * @param li     [in] sphinxbase file line iterator that point to bigram description in ARPA file
  * @param wid    [in] hashtable that maps string word representation to id
- * @param lmath  [in] log math used for log convertions
+ * @param lmath  [in] log math used for log conversions
  * @param counts [in] amount of ngrams for each order
  * @param order  [in] maximum order of ngrams
  * @return            raw ngrams of order bigger than 1
@@ -76,11 +76,11 @@ ngram_raw_t **ngrams_raw_read_arpa(lineiter_t ** li, logmath_t * lmath,
 /**
  * Reads ngrams of order > 1 from DMP file.
  * @param fp           [in] file to read from. Position in file corresponds to start of bigram description
- * @param lmath        [in] log math used for log convertions
+ * @param lmath        [in] log math used for log conversions
  * @param counts       [in] amount of ngrams for each order
  * @param order        [in] maximum order of ngrams
- * @param unigram_next [in] array of next word pointers for unigrams. Needed to define forst word of bigrams
- * @param do_swap      [in] wether to do swap of bits
+ * @param unigram_next [in] array of next word pointers for unigrams. Needed to define first word of bigrams
+ * @param do_swap      [in] whether to do swap of bits
  * @return                  raw ngrams of order bigger than 1
  */
 ngram_raw_t **ngrams_raw_read_dmp(FILE * fp, logmath_t * lmath,

--- a/src/mdef.c
+++ b/src/mdef.c
@@ -531,7 +531,7 @@ mdef_init(char *mdeffile, int32 breport)
         return NULL;
     }
     if (strncmp(buf, MODEL_DEF_VERSION, strlen(MODEL_DEF_VERSION)) != 0)
-        E_FATAL("Version error: Expecing %s, but read %s\n",
+        E_FATAL("Version error: Expecting %s, but read %s\n",
                 MODEL_DEF_VERSION, buf);
 
     /* Read #base phones, #triphones, #senone mappings defined in header */

--- a/src/ms_gauden.c
+++ b/src/ms_gauden.c
@@ -158,7 +158,7 @@ gauden_param_read(const char *file_name,
 
     /* #Codebooks */
     if (bio_fread(&n_mgau, sizeof(int32), 1, fp, byteswap, &chksum) != 1) {
-        E_ERROR("Failed to read number fo codebooks from %s\n", file_name);
+        E_ERROR("Failed to read number of codebooks from %s\n", file_name);
         fclose(fp);
         return NULL;
     }

--- a/src/ngram_search.h
+++ b/src/ngram_search.h
@@ -221,7 +221,7 @@ struct ngram_search_s {
      * The word triphone sequences (HMM instances) are transformed
      * into tree structures, one tree per unique left triphone in the
      * entire dictionary (actually diphone, since its left context
-     * varies dyamically during the search process).  The entire set
+     * varies dynamically during the search process).  The entire set
      * of trees of channels is allocated once and for all during
      * initialization (since dynamic management of active CHANs is
      * time consuming), with one exception: the last phones of words,

--- a/src/ps_lattice.c
+++ b/src/ps_lattice.c
@@ -851,7 +851,7 @@ ps_lattice_hyp(ps_lattice_t *dag, ps_latlink_t *link)
 
     /* Backtrace again to construct hypothesis string. */
     ckd_free(dag->hyp_str);
-    dag->hyp_str = ckd_calloc(1, len+1); /* extra one incase the hyp is empty */
+    dag->hyp_str = ckd_calloc(1, len+1); /* extra one in case the hyp is empty */
     c = dag->hyp_str + len - 1;
     if (dict_real_word(dag->dict, link->to->basewid)) {
 	char *wstr = dict_wordstr(dag->dict, link->to->basewid);
@@ -988,7 +988,7 @@ ps_lattice_seg_next(ps_seg_t *seg)
         return NULL;
     }
     else if (itor->cur == itor->n_links) {
-        /* Re-use the last link but with the "to" node. */
+        /* Reuse the last link but with the "to" node. */
         ps_lattice_link2itor(seg, itor->links[itor->cur - 1], TRUE);
     }
     else {

--- a/src/rtc_base/checks.h
+++ b/src/rtc_base/checks.h
@@ -11,7 +11,7 @@
 #ifndef RTC_BASE_CHECKS_H_
 #define RTC_BASE_CHECKS_H_
 
-// If you for some reson need to know if DCHECKs are on, test the value of
+// If you for some reason need to know if DCHECKs are on, test the value of
 // RTC_DCHECK_IS_ON. (Test its value, not if it's defined; it'll always be
 // defined, to either a true or a false value.)
 #if !defined(NDEBUG) || defined(DCHECK_ALWAYS_ON)

--- a/src/util/README.python
+++ b/src/util/README.python
@@ -22,8 +22,8 @@ properly. Assuming that you have an unpacked LAPACK source tree in
 $ python ./make_lite.py wrapped_routines ~/LAPACK new-lite/
 
 This will grab the right routines, with dependencies, put them into the
-appropiate ``blas_lite.f``, ``dlapack_lite.f``, or ``zlapack_lite.f`` files,
-run ``f2c`` over them, then do some scrubbing similiar to that done to
+appropriate ``blas_lite.f``, ``dlapack_lite.f``, or ``zlapack_lite.f`` files,
+run ``f2c`` over them, then do some scrubbing similar to that done to
 generate the CLAPACK_ distribution.
 
 .. _CLAPACK: http://netlib.org/clapack/index.html

--- a/src/util/bio.h
+++ b/src/util/bio.h
@@ -165,7 +165,7 @@ int32 bio_fread (void *buf,		/**< In: buffer to write */
 /**
  * Like fwrite but perform byteswapping and accumulate checksum (the 2 extra arguments).
  *
- * @return the number of elemens written (like fwrite).
+ * @return the number of elements written (like fwrite).
  */
 int32 bio_fwrite(const void *buf,	/**< In: buffer to write */
 		 int32 el_sz,		/**< In: element size */

--- a/src/util/bitvec.h
+++ b/src/util/bitvec.h
@@ -77,7 +77,7 @@ typedef uint32 bitvec_t;
  */
 bitvec_t *bitvec_realloc(bitvec_t *vec,	/* In: Bit vector to search */
 			 size_t old_len, /* In: Old length */
-                         size_t new_len); /* In: New lenght of above bit vector */
+                         size_t new_len); /* In: New length of above bit vector */
 /**
  * Free a bit vector.
  */
@@ -142,7 +142,7 @@ bitvec_t *bitvec_realloc(bitvec_t *vec,	/* In: Bit vector to search */
  * @return the number of bits being set in vector <code>vec</code>
  */
 size_t bitvec_count_set(bitvec_t *vec,	/* In: Bit vector to search */
-                        size_t len);	/* In: Lenght of above bit vector */
+                        size_t len);	/* In: Length of above bit vector */
 
 #ifdef __cplusplus
 }

--- a/src/util/clapack_scrub.py
+++ b/src/util/clapack_scrub.py
@@ -226,7 +226,7 @@ def removeHeader(source):
     return lines.getValue()
 
 def replaceSlamch(source):
-    """Replace slamch_ calls with appropiate macros"""
+    """Replace slamch_ calls with appropriate macros"""
     def repl(m):
         s = m.group(1)
         return dict(E='EPSILON', P='PRECISION', S='SAFEMINIMUM',

--- a/src/util/cmd_ln.h
+++ b/src/util/cmd_ln.h
@@ -176,7 +176,7 @@ cmd_ln_t *cmd_ln_retain(cmd_ln_t *cmdln);
 int cmd_ln_free_r(cmd_ln_t *cmdln);
 
 /**
- * Parse a list of strings into argumetns.
+ * Parse a list of strings into arguments.
  *
  * Parse the given list of arguments (name-value pairs) according to
  * the given definitions.  Argument values can be retrieved in future

--- a/src/util/fortran.py
+++ b/src/util/fortran.py
@@ -12,7 +12,7 @@ def isContinuation(line):
 
 COMMENT, STATEMENT, CONTINUATION = 0, 1, 2
 def lineType(line):
-    """Return the type of a line of Fortan code."""
+    """Return the type of a line of Fortran code."""
     if isBlank(line):
         return COMMENT
     elif isLabel(line):

--- a/src/util/glist.h
+++ b/src/util/glist.h
@@ -138,13 +138,13 @@ glist_t glist_add_uint32 (glist_t g,  /**< a link list */
  * Create and prepend a new list node containing a single-precision float.
  */  
 glist_t glist_add_float32 (glist_t g, /**< a link list */
-			   float32 val /**< a float32 vlaue */
+			   float32 val /**< a float32 value */
 	);
 /**
  * Create and prepend a new list node containing a double-precision float.
  */  
 glist_t glist_add_float64 (glist_t g, /**< a link list */
-			   float64 val  /**< a float64 vlaue */
+			   float64 val  /**< a float64 value */
 	);
 
 

--- a/src/util/listelem_alloc.h
+++ b/src/util/listelem_alloc.h
@@ -104,7 +104,7 @@ void __listelem_free__(listelem_alloc_t *le, void *elem, char *file, int line);
 #define listelem_free(le,el)	__listelem_free__((le),(el),__FILE__,__LINE__)
 
 /**
-   Print number of allocation, numer of free operation stats 
+   Print number of allocation, number of free operation stats 
 */
 void listelem_stats(listelem_alloc_t *le);
 

--- a/src/util/matrix.c
+++ b/src/util/matrix.c
@@ -173,8 +173,8 @@ determinant(float32 ** a, int32 n)
 
 int32
 solve(float32 **a, /*Input : an n*n matrix A */
-      float32 *b,  /*Input : a n dimesion vector b */
-      float32 *out_x,  /*Output : a n dimesion vector x */
+      float32 *b,  /*Input : a n dimension vector b */
+      float32 *out_x,  /*Output : a n dimension vector x */
       int32   n)
 {
     char uplo;

--- a/src/util/slapack_lite.c
+++ b/src/util/slapack_lite.c
@@ -55,7 +55,7 @@ integer ieeeck_(integer *ispec, real *zero, real *one)
     =========
 
     ISPEC   (input) INTEGER
-            Specifies whether to test just for inifinity arithmetic
+            Specifies whether to test just for infinity arithmetic
             or whether to test for infinity and NaN arithmetic.
             = 0: Verify infinity arithmetic only.
             = 1: Verify infinity and NaN arithmetic.

--- a/src/util/strfuncs.h
+++ b/src/util/strfuncs.h
@@ -110,7 +110,7 @@ int32 str2words (char *line,	/**< In/Out: line to be parsed.  This
 				   must be allocated by the caller.
 				   It may be NULL in which case the
 				   number of words will be counted.
-				   This allows you to allcate it to
+				   This allows you to allocate it to
 				   the proper size, e.g.:
 				   
 				   n = str2words(line, NULL, 0);

--- a/test/unit/test_feat/test_feat_fe.c
+++ b/test/unit/test_feat/test_feat_fe.c
@@ -77,7 +77,7 @@ main(int argc, char *argv[])
 	ncep = 1;
 	nfr = feat_s2mfc2feat_live(fcb, cptr, &ncep, TRUE, FALSE, fptr);
 	TEST_EQUAL(nfr, 0); /* Not possible to make any frames yet. */
-	TEST_EQUAL(ncep, 1); /* But we shold have consumed one. */
+	TEST_EQUAL(ncep, 1); /* But we should have consumed one. */
 	cptr += ncep;
 	for (i = 1; i < total_frames - 1; ++i) {
 		ncep = 1;


### PR DESCRIPTION
% `codespell --ignore-words-list=delt,dout,fo,nd,noes --skip="cmudict-en-us.dict" --write-changes`
https://pypi.org/project/codespell