### PR TITLE
Fix stack-buffer overflow in WAV chunk ID logging

### DIFF
--- a/src/util/soundfiles.c
+++ b/src/util/soundfiles.c
@@ -206,7 +206,7 @@ ps_config_wavfile(ps_config_t *config, FILE *infh, const char *file)
             /* Avoid seeking... */
             spam = malloc(intval);
             if (fread(spam, 1, intval, infh) != (size_t)intval) {
-                E_ERROR_SYSTEM("%s: Failed to read %s chunk", file, id);
+                E_ERROR_SYSTEM("%s: Failed to read %c%c%c%c chunk", file, id[0], id[1], id[2], id[3]);
                 rv = -1;
             }
             ckd_free(spam);


### PR DESCRIPTION
## Description

Fixes a stack-buffer overflow vulnerability when logging 4-byte WAV chunk IDs in `ps_config_wavfile`.

The issue occurs when processing malformed WAV files with unknown chunks. The code used `%s` format specifier with a non-null-terminated `char[4]` buffer, which could read past the buffer boundary during logging.

**Changes:**
- Replaced `%s` format specifier with `%c%c%c%c`
- Pass individual characters `id[0]`, `id[1]`, `id[2]`, `id[3]` to prevent buffer over-read

## Verification steps

- Compiled successfully with no errors
- Prevents AddressSanitizer stack-buffer-overflow reported in the issue
- All other uses of the `id` buffer use safe operations (memcmp with explicit length)

Fixes #431