### PR TITLE
Remove deprecated pygtkcompat dependency from livedemo.py

### DIFF
--- a/gst/livedemo.py
+++ b/gst/livedemo.py
@@ -6,22 +6,17 @@
 # the CMU Sphinx system. See LICENSE for more information.
 
 
-from gi import pygtkcompat
 import gi
 
 gi.require_version('Gst', '1.0')
-from gi.repository import GObject, Gst
+gi.require_version('Gtk', '3.0')
+from gi.repository import GObject, Gst, Gtk
 GObject.threads_init()
 Gst.init(None)
     
 gst = Gst
     
-print("Using pygtkcompat and Gst from gi")
-
-pygtkcompat.enable() 
-pygtkcompat.enable_gtk(version='3.0')
-
-import gtk
+print("Using PyGObject and Gst from gi")
 
 class DemoApp(object):
     """GStreamer/PocketSphinx Demo Application"""
@@ -32,16 +27,16 @@ class DemoApp(object):
 
     def init_gui(self):
         """Initialize the GUI components"""
-        self.window = gtk.Window()
-        self.window.connect("delete-event", gtk.main_quit)
+        self.window = Gtk.Window()
+        self.window.connect("delete-event", Gtk.main_quit)
         self.window.set_default_size(400,200)
         self.window.set_border_width(10)
-        vbox = gtk.VBox()
-        self.textbuf = gtk.TextBuffer()
-        self.text = gtk.TextView(buffer=self.textbuf)
-        self.text.set_wrap_mode(gtk.WRAP_WORD)
+        vbox = Gtk.VBox()
+        self.textbuf = Gtk.TextBuffer()
+        self.text = Gtk.TextView(buffer=self.textbuf)
+        self.text.set_wrap_mode(Gtk.WrapMode.WORD)
         vbox.pack_start(self.text)
-        self.button = gtk.ToggleButton("Speak")
+        self.button = Gtk.ToggleButton("Speak")
         self.button.connect('clicked', self.button_clicked)
         vbox.pack_start(self.button, False, False, 5)
         self.window.add(vbox)
@@ -101,4 +96,4 @@ class DemoApp(object):
             self.pipeline.set_state(gst.State.PAUSED)
 
 app = DemoApp()
-gtk.main()
+Gtk.main()


### PR DESCRIPTION
## Description

Fixes #440 - Remove deprecated pygtkcompat dependency from gst/livedemo.py

As reported in [Debian bug #1118277](https://bugs.debian.org/1118277), the `gst/livedemo.py` file relies on `pygtkcompat`, which was removed after PyGObject 3.50.x series.

## Changes Made

- Remove `pygtkcompat` import and enable calls
- Add `gi.require_version('Gtk', '3.0')` requirement  
- Update GTK API calls to use `Gtk.*` instead of `gtk.*`
- Update wrap mode constant to `Gtk.WrapMode.WORD`
- Update main loop call to `Gtk.main()`

## Verification Steps

- [x] Syntax check passes: `python3 -m py_compile gst/livedemo.py`
- [x] Imports work with modern PyGObject: `python3 -c "import gi; gi.require_version('Gst', '1.0'); gi.require_version('Gtk', '3.0'); from gi.repository import GObject, Gst, Gtk; print('PyGObject dependencies available')"`
- [x] No more pygtkcompat dependency errors

The changes are minimal and maintain full functionality while removing the deprecated dependency.