### PR TITLE
Handle mmap failures correctly

### DIFF
--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -401,18 +401,21 @@ bin_mdef_read(ps_config_t *config, const char *filename)
 
     /* Decide whether to read in the whole file or mmap it. */
     do_mmap = config ? ps_config_bool(config, "mmap") : TRUE;
-    if (swap) {
-        E_WARN("-mmap specified, but mdef is other-endian.  Will not memory-map.\n");
+    if (do_mmap && swap) {
+        E_WARN("-mmap specified, but %s is other-endian.  Will not memory-map.\n",
+               filename);
         do_mmap = FALSE;
     } 
     /* Actually try to mmap it. */
     if (do_mmap) {
         m->filemap = mmio_file_read(filename);
-        if (m->filemap == NULL)
+        if (m->filemap == NULL) {
+            E_ERROR_SYSTEM("-mmap specified, but memory mapping of %s failed", filename);
             do_mmap = FALSE;
+        }
     }
     pos = ftell(fh);
-    if (do_mmap) {
+    if (m->filemap) {
         /* Get the base pointer from the memory map. */
         m->ciname[0] = (char *)mmio_file_ptr(m->filemap) + pos;
         /* Success! */

--- a/src/ptm_mgau.c
+++ b/src/ptm_mgau.c
@@ -599,6 +599,13 @@ read_sendump(ptm_mgau_t *s, bin_mdef_t *mdef, char const *file)
     /* Allocate memory for pdfs (or memory map them) */
     if (do_mmap) {
         s->sendump_mmap = mmio_file_read(file);
+        if (s->sendump_mmap == NULL) {
+            E_ERROR_SYSTEM("%s: memory mapping failed, falling back to stdio", file);
+            do_mmap = FALSE;
+        }
+    }
+
+    if (s->sendump_mmap) {
         /* Get cluster codebook if any. */
         if (n_clust) {
             s->mixw_cb = ((uint8 *) mmio_file_ptr(s->sendump_mmap)) + offset;

--- a/src/s2_semi_mgau.c
+++ b/src/s2_semi_mgau.c
@@ -1028,6 +1028,13 @@ read_sendump(s2_semi_mgau_t *s, bin_mdef_t *mdef, char const *file)
     /* Allocate memory for pdfs (or memory map them) */
     if (do_mmap) {
         s->sendump_mmap = mmio_file_read(file);
+        if (s->sendump_mmap == NULL) {
+            E_ERROR_SYSTEM("%s: memory mapping failed, falling back to stdio", file);
+            do_mmap = FALSE;
+        }
+    }
+
+    if (s->sendump_mmap) {
         /* Get cluster codebook if any. */
         if (n_clust) {
             s->mixw_cb = ((uint8 *) mmio_file_ptr(s->sendump_mmap)) + offset;

--- a/src/util/logmath.c
+++ b/src/util/logmath.c
@@ -164,7 +164,7 @@ logmath_init(float64 base, int shift, int use_table)
 logmath_t *
 logmath_read(const char *file_name)
 {
-    logmath_t *lmath;
+    logmath_t *lmath = NULL;
     char **argname, **argval;
     int32 byteswap, i;
     int chksum_present, do_mmap;
@@ -181,8 +181,7 @@ logmath_read(const char *file_name)
     /* Read header, including argument-value info and 32-bit byteorder magic */
     if (bio_readhdr(fp, &argname, &argval, &byteswap) < 0) {
         E_ERROR("Failed to read the header from the file '%s'\n", file_name);
-        fclose(fp);
-        return NULL;
+        goto error_out;
     }
 
     lmath = ckd_calloc(1, sizeof(*lmath));
@@ -227,24 +226,33 @@ logmath_read(const char *file_name)
         goto error_out;
     }
 
+    /* We have no config argument, so, will always mmap unless it's not possible. */
+    do_mmap = TRUE;
+
     /* Check alignment constraints for memory mapping */
-    do_mmap = 1;
     pos = ftell(fp);
     if (pos & ((long)lmath->t.width - 1)) {
         E_WARN("%s: Data start %ld is not aligned on %d-byte boundary, will not memory map\n",
                   file_name, pos, lmath->t.width);
-        do_mmap = 0;
+        do_mmap = FALSE;
     }
     /* Check byte order for memory mapping */
     if (byteswap) {
         E_WARN("%s: Data is wrong-endian, will not memory map\n", file_name);
-        do_mmap = 0;
+        do_mmap = FALSE;
     }
 
     if (do_mmap) {
         lmath->filemap = mmio_file_read(file_name);
-        lmath->t.table = (char *)mmio_file_ptr(lmath->filemap) + pos;
+        if (lmath->filemap == NULL) {
+            E_ERROR_SYSTEM("%s: memory mapping failed, falling back to stdio", file_name);
+            do_mmap = FALSE;
+        }
     }
+
+    /* Map or allocate the table depending on whether a mapping exists */
+    if (lmath->filemap)
+        lmath->t.table = (char *)mmio_file_ptr(lmath->filemap) + pos;
     else {
         lmath->t.table = ckd_calloc(lmath->t.table_size, lmath->t.width);
         if ((uint32)bio_fread(lmath->t.table, lmath->t.width, lmath->t.table_size,
@@ -254,7 +262,7 @@ logmath_read(const char *file_name)
             goto error_out;
         }
         if (chksum_present)
-            bio_verify_chksum(fp, byteswap, chksum);
+            bio_verify_chksum(fp, byteswap, chksum);  /* does not return on error */
 
         if (fread(&i, 1, 1, fp) == 1) {
             E_ERROR("%s: More data than expected\n", file_name);
@@ -262,9 +270,10 @@ logmath_read(const char *file_name)
         }
     }
     fclose(fp);
-
     return lmath;
+
 error_out:
+    fclose(fp);
     logmath_free(lmath);
     return NULL;
 }

--- a/test/unit/test_log_shifted.c
+++ b/test/unit/test_log_shifted.c
@@ -46,6 +46,8 @@ main(int argc, char *argv[])
 	rv = logmath_write(lmath, "tmp.logadd");
 	TEST_EQUAL(rv, 0);
 	logmath_free(lmath);
+	lmath = logmath_read("NON_EXISTENT_FOO.logadd");
+	TEST_ASSERT(lmath == NULL);
 	lmath = logmath_read("tmp.logadd");
 	TEST_ASSERT(lmath);
 	printf("log(1e-150) = %d\n", logmath_log(lmath, 1e-150));


### PR DESCRIPTION
In a number of places we were not checking the return value of `mmio_file_read`, which could lead to NULL pointer dereferences.

Fixes: #462