### PR TITLE
fix: refcount lmath in fsg to fix memory leak in jsgf2fsg

### DIFF
--- a/programs/pocketsphinx_jsgf2fsg.c
+++ b/programs/pocketsphinx_jsgf2fsg.c
@@ -127,6 +127,7 @@ get_fsg(jsgf_t *grammar, const char *name)
 
     lmath = logmath_init(1.0001, 0, 0);
     fsg = jsgf_build_fsg_raw(grammar, rule, lmath, 1.0);
+    logmath_free(lmath);
     return fsg;
 }
 
@@ -196,6 +197,7 @@ main(int argc, char *argv[])
     }
     fsg_model_free(fsg);
     jsgf_grammar_free(jsgf);
+    ps_config_free(config);
 
     return 0;
 }

--- a/src/lm/fsg_model.c
+++ b/src/lm/fsg_model.c
@@ -38,6 +38,7 @@
 
 #include <pocketsphinx.h>
 
+#include "pocketsphinx/logmath.h"
 #include "util/pio.h"
 #include "util/ckd_alloc.h"
 #include "util/strfuncs.h"
@@ -502,7 +503,7 @@ fsg_model_init(char const *name, logmath_t * lmath, float32 lw,
     fsg = ckd_calloc(1, sizeof(*fsg));
     fsg->refcount = 1;
     fsg->link_alloc = listelem_alloc_init(sizeof(fsg_link_t));
-    fsg->lmath = lmath;
+    fsg->lmath = logmath_retain(lmath);
     fsg->name = name ? ckd_salloc(name) : NULL;
     fsg->n_state = n_state;
     fsg->lw = lw;
@@ -782,6 +783,7 @@ fsg_model_free(fsg_model_t * fsg)
     listelem_alloc_free(fsg->link_alloc);
     bitvec_free(fsg->silwords);
     bitvec_free(fsg->altwords);
+    logmath_free(fsg->lmath);
     ckd_free(fsg->name);
     ckd_free(fsg);
     return 0;


### PR DESCRIPTION
For `$REASONS` we were not refcounting `fsg->lmath` and expecting it to be owned by the parent context.

Adding a retain/free around it doesn't change anything to these semantics but allows us to avoid leaking memory.