### PR TITLE
Enable Windows ARM64 builds in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     needs: build_sdist
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,10 @@ jobs:
           - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
+          - windows-11-arm
+        exclude:
+          - os: windows-11-arm
+            py: "3.8"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # was: actions/checkout@v6
       - name: Setup python for test ${{ matrix.py }}


### PR DESCRIPTION
Adds Windows ARM64 support to the PocketSphinx CI workflow by introducing a Windows ARM64 CI job and enabling builds on Windows ARM64 runners.