### PR TITLE
Make ps_start_stream() succeed when noise removal is disabled

### DIFF
--- a/include/pocketsphinx.h
+++ b/include/pocketsphinx.h
@@ -771,7 +771,9 @@ int ps_decode_senscr(ps_decoder_t *ps, FILE *senfh);
  *
  * @deprecated This function is retained for compatibility, but its
  * only effect is to reset the noise removal statistics, which are
- * otherwise retained across utterances.  You do not need to call it.
+ * otherwise retained across utterances.  If noise removal is disabled,
+ * there are no statistics to reset and this is a successful no-op.  You
+ * do not need to call it.
  *
  * @memberof ps_decoder_t
  * @return 0 for success, <0 on error.

--- a/src/fe/fe_noise.c
+++ b/src/fe/fe_noise.c
@@ -62,7 +62,6 @@
 #include "fe/fe_internal.h"
 
 /* Noise suppression constants */
-#define SMOOTH_WINDOW 4
 #define LAMBDA_POWER 0.7
 #define LAMBDA_A 0.995
 #define LAMBDA_B 0.5
@@ -72,41 +71,6 @@
 #define SLOW_PEAK_FORGET_FACTOR 0.9995
 #define SLOW_PEAK_LEARN_FACTOR 0.9
 #define SPEECH_VOLUME_RANGE 8.0
-
-struct noise_stats_s {
-    /* Smoothed power */
-    powspec_t *power;
-    /* Noise estimate */
-    powspec_t *noise;
-    /* Signal floor estimate */
-    powspec_t *floor;
-    /* Peak for temporal masking */
-    powspec_t *peak;
-    /* Buffers used in update_noisestats */
-    powspec_t *signal, *gain;
-
-    /* Initialize it next time */
-    int undefined;
-    /* Number of items to process */
-    int num_filters;
-
-    /* Sum of slow peaks for VAD */
-    powspec_t slow_peak_sum;
-
-    /* Precomputed constants */
-    powspec_t lambda_power;
-    powspec_t comp_lambda_power;
-    powspec_t lambda_a;
-    powspec_t comp_lambda_a;
-    powspec_t lambda_b;
-    powspec_t comp_lambda_b;
-    powspec_t lambda_t;
-    powspec_t mu_t;
-    powspec_t max_gain;
-    powspec_t inv_max_gain;
-
-    powspec_t smooth_scaling[2 * SMOOTH_WINDOW + 3];
-};
 
 static void
 fe_lower_envelope(noise_stats_t *noise_stats, const powspec_t *buf, powspec_t *floor_buf, int32 num_filt)

--- a/src/fe/fe_noise.h
+++ b/src/fe/fe_noise.h
@@ -43,6 +43,43 @@
 
 typedef struct noise_stats_s noise_stats_t;
 
+#define SMOOTH_WINDOW 4
+
+struct noise_stats_s {
+    /* Smoothed power */
+    powspec_t *power;
+    /* Noise estimate */
+    powspec_t *noise;
+    /* Signal floor estimate */
+    powspec_t *floor;
+    /* Peak for temporal masking */
+    powspec_t *peak;
+    /* Buffers used in update_noisestats */
+    powspec_t *signal, *gain;
+
+    /* Initialize it next time */
+    int undefined;
+    /* Number of items to process */
+    int num_filters;
+
+    /* Sum of slow peaks for VAD */
+    powspec_t slow_peak_sum;
+
+    /* Precomputed constants */
+    powspec_t lambda_power;
+    powspec_t comp_lambda_power;
+    powspec_t lambda_a;
+    powspec_t comp_lambda_a;
+    powspec_t lambda_b;
+    powspec_t comp_lambda_b;
+    powspec_t lambda_t;
+    powspec_t mu_t;
+    powspec_t max_gain;
+    powspec_t inv_max_gain;
+
+    powspec_t smooth_scaling[2 * SMOOTH_WINDOW + 3];
+};
+
 /* Creates noisestats object */
 noise_stats_t *fe_init_noisestats(int num_filters);
 

--- a/src/pocketsphinx.c
+++ b/src/pocketsphinx.c
@@ -1076,8 +1076,6 @@ ps_start_stream(ps_decoder_t *ps)
         return -1;
     if (ps->acmod->fe == NULL)
         return -1;
-    if (ps->acmod->fe->noise_stats == NULL)
-        return -1;
     fe_reset_noisestats(ps->acmod->fe->noise_stats);
     return 0;
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TESTS
   test_senfh
   test_set_search
   test_simple
+  test_start_stream
   test_state_align
   test_vad
   test_vad_alloc

--- a/test/unit/test_start_stream.c
+++ b/test/unit/test_start_stream.c
@@ -1,0 +1,47 @@
+#include <pocketsphinx.h>
+
+#include "pocketsphinx_internal.h"
+#include "fe/fe_internal.h"
+#include "fe/fe_noise.h"
+#include "test_macros.h"
+
+static ps_config_t *
+make_config(void)
+{
+    return ps_config_parse_json(
+        NULL,
+        "hmm: \"" DATADIR "/an4_ci_cont\","
+        "lm: \"" DATADIR "/turtle.lm.bin\","
+        "dict: \"" DATADIR "/turtle.dic\","
+        "samprate: 16000");
+}
+
+int
+main(int argc, char *argv[])
+{
+    ps_config_t *config;
+    ps_decoder_t *ps;
+
+    (void)argc;
+    (void)argv;
+
+    TEST_ASSERT(config = make_config());
+    TEST_ASSERT(ps = ps_init(config));
+    TEST_ASSERT(!ps_config_bool(ps_get_config(ps), "remove_noise"));
+    TEST_EQUAL(0, ps_start_stream(ps));
+    ps_free(ps);
+    ps_config_free(config);
+
+    TEST_ASSERT(config = make_config());
+    TEST_ASSERT(ps_config_set_bool(config, "remove_noise", TRUE));
+    TEST_ASSERT(ps = ps_init(config));
+    TEST_ASSERT(ps_config_bool(ps_get_config(ps), "remove_noise"));
+    TEST_ASSERT(ps->acmod->fe->noise_stats != NULL);
+    ps->acmod->fe->noise_stats->undefined = FALSE;
+    TEST_EQUAL(0, ps_start_stream(ps));
+    TEST_ASSERT(ps->acmod->fe->noise_stats->undefined);
+    ps_free(ps);
+    ps_config_free(config);
+
+    return 0;
+}


### PR DESCRIPTION
`ps_start_stream()` returned -1 whenever noise removal was disabled, which is the shipped default (`-remove_noise no`). The front end allocates noise statistics only when noise removal is enabled, and `ps_start_stream()` treated their absence as an error, so a caller of this documented compatibility function got a failure return from a successfully initialized decoder. The header states no such precondition, and `fe_reset_noisestats()` is already a no-op on a null pointer.

The fix calls `fe_reset_noisestats()` unconditionally and returns 0; when there are no statistics to reset the call is a successful no-op, now stated in the header documentation. Behavior with noise removal enabled is unchanged.

A first commit moves the `noise_stats_s` definition from `fe_noise.c` into the internal header `fe_noise.h`, with no functional change, so internal consumers can compile against the real layout instead of duplicating it.

The new unit test `test_start_stream` initializes a real decoder both ways: with noise removal disabled it asserts a zero return, and with it enabled it asserts the statistics are actually reset. The disabled case fails against the previous implementation.

Fixes #496

Tested on macOS (Apple clang) and Linux x86-64 (GCC 13.3); full unit and regression suite passes on both.
