### PR TITLE
Disable bestpath for the forced-alignment search

### DIFF
--- a/src/fsg_search.c
+++ b/src/fsg_search.c
@@ -243,6 +243,13 @@ fsg_search_init(const char *name,
         fsgs->bestpath = TRUE;
 #endif
 
+    /* Forced alignment must use the Viterbi backtrace, not the lattice
+     * bestpath: the latter's segmentation can give phones durations too
+     * short for their HMMs, corrupting the state alignment.  The align
+     * CLI already disables bestpath; do the same for the _align search. */
+    if (name != NULL && strcmp(name, PS_DEFAULT_ALIGN_SEARCH) == 0)
+        fsgs->bestpath = FALSE;
+
     if (fsg_search_reinit(ps_search_base(fsgs),
                           ps_search_dict(fsgs),
                           ps_search_dict2pid(fsgs)) < 0)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TESTS
   test_acmod
   test_acmod_grow
   test_alignment
+  test_align_bestpath
   test_allphone
   test_bitvec
   test_config

--- a/test/unit/test_align_bestpath.c
+++ b/test/unit/test_align_bestpath.c
@@ -1,0 +1,68 @@
+/* -*- c-basic-offset: 4 -*- */
+#include <stdarg.h>
+#include <string.h>
+
+#include <pocketsphinx.h>
+
+#include "test_macros.h"
+
+#define ALIGN_TEXT "feels like these days go on forever"
+
+static void
+capture_error(void *user_data, err_lvl_t level, const char *fmt, ...)
+{
+    char message[1024];
+    va_list args;
+
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+    if (strstr(message, "impossible duration") != NULL)
+        *(int *)user_data = TRUE;
+    (void)level;
+}
+
+static int
+decode_wav(ps_decoder_t *ps)
+{
+    FILE *rawfh;
+    long nsamp;
+
+    TEST_ASSERT(rawfh = fopen(DATADIR "/forever/input_2_16k.wav", "rb"));
+    TEST_EQUAL(0, fseek(rawfh, 44, SEEK_SET));
+    nsamp = ps_decode_raw(ps, rawfh, -1);
+    fclose(rawfh);
+    TEST_ASSERT(nsamp > 0);
+    return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+    ps_config_t *config;
+    ps_decoder_t *ps;
+    int impossible_duration = FALSE;
+
+    (void)argc;
+    (void)argv;
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "lm: \"" MODELDIR "/en-us/en-us.lm.bin\","
+                    "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\""));
+    TEST_ASSERT(ps_config_bool(config, "bestpath"));
+    TEST_ASSERT(ps = ps_init(config));
+    err_set_callback(capture_error, &impossible_duration);
+
+    TEST_EQUAL(0, ps_set_align_text(ps, ALIGN_TEXT));
+    decode_wav(ps);
+    TEST_EQUAL(0, ps_set_alignment(ps, NULL));
+    decode_wav(ps);
+
+    err_set_callback(err_logfp_cb, NULL);
+    TEST_ASSERT(impossible_duration == FALSE);
+    ps_free(ps);
+    ps_config_free(config);
+    return 0;
+}


### PR DESCRIPTION
Forced alignment builds an FSG search named `_align`. When the global `bestpath` option is enabled — which is the default — that search generates its result from a word lattice instead of the Viterbi backtrace. The lattice segmentation can assign a phone fewer frames than its HMM has emitting states, so the second alignment pass reports `phone N has impossible duration` (`state_align_search.c`) and the resulting state alignment is corrupted. The `align` command already disables bestpath for this reason; a caller using the library alignment API (`ps_set_align_text` / `ps_set_alignment`) got no such protection.

This forces `bestpath` off for the `_align` search only, in `fsg_search_init`, so the library alignment path uses the Viterbi backtrace regardless of the global setting. Other FSG, JSGF, and keyword searches are unaffected and keep bestpath.

`test_align_bestpath` runs both alignment passes over a shipped fixture with bestpath enabled and asserts that no phone receives an impossible duration. It fails against the previous behavior.

This addresses the forced-alignment breakage described in #318. The other concerns raised there — whether bestpath should default off for FSG search generally, and the lattice start/end node construction — are not touched here.

Tested on macOS (Apple clang) and Linux x86-64 (GCC 13.3); full unit and regression suite passes on both.
