### PR TITLE
Reconcile ARPA writer output with actual trie counts

### DIFF
--- a/src/lm/lm_trie.c
+++ b/src/lm/lm_trie.c
@@ -827,7 +827,7 @@ lm_trie_score(lm_trie_t * trie, int order, int32 wid, int32 * hist,
 void
 lm_trie_fill_raw_ngram(lm_trie_t * trie,
     		       ngram_raw_t * raw_ngrams, uint32 * raw_ngram_idx,
-            	       uint32 * counts, node_range_t range, uint32 * hist,
+            	       uint32 capacity, uint32 * counts, node_range_t range, uint32 * hist,
     	               int n_hist, int order, int max_order)
 {
     if (n_hist > 0 && range.begin == range.end) {
@@ -839,7 +839,7 @@ lm_trie_fill_raw_ngram(lm_trie_t * trie,
             node_range_t node;
             unigram_find(trie->unigrams, i, &node);
             hist[0] = i;
-            lm_trie_fill_raw_ngram(trie, raw_ngrams, raw_ngram_idx, counts,
+            lm_trie_fill_raw_ngram(trie, raw_ngrams, raw_ngram_idx, capacity, counts,
                            node, hist, 1, order, max_order);
         }
     }
@@ -866,7 +866,7 @@ lm_trie_fill_raw_ngram(lm_trie_t * trie,
             node.end =
                 bitarr_read_int25(address, middle->next_mask.bits,
                                   middle->next_mask.mask);
-            lm_trie_fill_raw_ngram(trie, raw_ngrams, raw_ngram_idx, counts,
+            lm_trie_fill_raw_ngram(trie, raw_ngrams, raw_ngram_idx, capacity, counts,
                            node, hist, n_hist + 1, order, max_order);
         }
     }
@@ -877,7 +877,12 @@ lm_trie_fill_raw_ngram(lm_trie_t * trie,
         int i;
         assert(n_hist == order - 1);
         for (ptr = range.begin; ptr < range.end; ptr++) {
-            ngram_raw_t *raw_ngram = &raw_ngrams[*raw_ngram_idx];
+            ngram_raw_t *raw_ngram;
+            if (*raw_ngram_idx >= capacity) {
+                (*raw_ngram_idx)++;
+                continue;
+            }
+            raw_ngram = &raw_ngrams[*raw_ngram_idx];
             if (order == max_order) {
                 longest_t *longest = trie->longest;
                 address.base = longest->base.base;

--- a/src/lm/lm_trie.h
+++ b/src/lm/lm_trie.h
@@ -104,7 +104,8 @@ void lm_trie_build(lm_trie_t * trie, ngram_raw_t ** raw_ngrams,
 
 void lm_trie_fill_raw_ngram(lm_trie_t * trie,
 			    ngram_raw_t * raw_ngrams, uint32 * raw_ngram_idx,
-            	            uint32 * counts, node_range_t range, uint32 * hist,
+            	            uint32 capacity, uint32 * counts,
+			    node_range_t range, uint32 * hist,
     	                    int n_hist, int order, int max_order);
 
 float lm_trie_score(lm_trie_t * trie, int order, int32 wid, int32 * hist,

--- a/src/lm/ngram_model_trie.c
+++ b/src/lm/ngram_model_trie.c
@@ -243,7 +243,29 @@ ngram_model_trie_write_arpa(ngram_model_t * base, const char *path)
     int i;
     uint32 j;
     ngram_model_trie_t *model = (ngram_model_trie_t *) base;
-    FILE *fp = fopen(path, "w");
+    uint32 counts[NGRAM_MAX_ORDER];
+    FILE *fp;
+
+    /* The header counts (base->n_counts) can disagree with the trie
+     * content for models built with an inconsistent header, so discover
+     * the true per-order counts by walking the trie before writing
+     * anything, and emit those counts so the output is self-consistent. */
+    counts[0] = base->n_counts[0];
+    for (i = 2; i <= base->n; ++i) {
+        uint32 raw_ngram_idx = 0;
+        uint32 hist[NGRAM_MAX_ORDER];
+        node_range_t range;
+        range.begin = range.end = 0;
+        lm_trie_fill_raw_ngram(model->trie, NULL, &raw_ngram_idx, 0,
+                               base->n_counts, range, hist, 0, i, base->n);
+        counts[i - 1] = raw_ngram_idx;
+        if (raw_ngram_idx != base->n_counts[i - 1])
+            E_WARN("Header %d-gram count %u does not match trie content %u, "
+                   "writing %u\n", i, base->n_counts[i - 1],
+                   raw_ngram_idx, raw_ngram_idx);
+    }
+
+    fp = fopen(path, "w");
     if (!fp) {
         E_ERROR("Unable to open %s to write arpa LM from trie\n", path);
         return -1;
@@ -253,7 +275,7 @@ ngram_model_trie_write_arpa(ngram_model_t * base, const char *path)
     /* Write N-gram counts. */
     fprintf(fp, "\\data\\\n");
     for (i = 0; i < base->n; ++i) {
-        fprintf(fp, "ngram %d=%d\n", i + 1, base->n_counts[i]);
+        fprintf(fp, "ngram %d=%d\n", i + 1, counts[i]);
     }
     /* Write 1-grams */
     fprintf(fp, "\n\\1-grams:\n");
@@ -272,7 +294,7 @@ ngram_model_trie_write_arpa(ngram_model_t * base, const char *path)
     if (base->n > 1) {
         for (i = 2; i <= base->n; ++i) {
             ngram_raw_t *raw_ngrams =
-                (ngram_raw_t *) ckd_calloc((size_t) base->n_counts[i - 1],
+                (ngram_raw_t *) ckd_calloc((size_t) counts[i - 1],
                                            sizeof(*raw_ngrams));
             uint32 raw_ngram_idx;
             uint32 j;
@@ -283,14 +305,13 @@ ngram_model_trie_write_arpa(ngram_model_t * base, const char *path)
 
             /* we need to iterate over a trie here. recursion should do the job */
             lm_trie_fill_raw_ngram(model->trie, raw_ngrams,
-                           &raw_ngram_idx, base->n_counts, range, hist, 0,
-                           i, base->n);
-            assert(raw_ngram_idx == base->n_counts[i - 1]);
-            qsort(raw_ngrams, (size_t) base->n_counts[i - 1],
+                           &raw_ngram_idx, counts[i - 1], base->n_counts,
+                           range, hist, 0, i, base->n);
+            qsort(raw_ngrams, (size_t) counts[i - 1],
                   sizeof(ngram_raw_t), &ngram_ord_comparator);
 
             fprintf(fp, "\n\\%d-grams:\n", i);
-            for (j = 0; j < base->n_counts[i - 1]; j++) {
+            for (j = 0; j < counts[i - 1]; j++) {
                 int k;
                 fprintf(fp, "%.4f", logmath_log_float_to_log10(base->lmath, raw_ngrams[j].prob));
                 for (k = 0; k < i; k++) {

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TESTS
   test-cards.sh
   test-lm.sh
   test-lm-convert.sh
+  test-lm-convert-mismatch.sh
   test-main.sh
   test-main-align.sh
   test-align.sh

--- a/test/regression/test-lm-convert-mismatch.sh
+++ b/test/regression/test-lm-convert-mismatch.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+: ${CMAKE_BINARY_DIR:=$(pwd)}
+. ${CMAKE_BINARY_DIR}/test/testfuncs.sh
+
+bn=`basename $0 .sh`
+
+echo "Test: $bn"
+
+# The shipped en-us model has an inconsistent header (it claims 2051547
+# bigrams but stores 2051541), which exercises the count-mismatch path in
+# the ARPA writer.
+lm=$model/en-us/en-us.lm.bin
+
+# The writer warns about the mismatch, does not crash, and writes the
+# actual counts found in the trie.
+rm -f $bn.arpa
+run_program pocketsphinx_lm_convert \
+            -i $lm \
+            -o $bn.arpa \
+            > $bn.log 2>&1
+status=$?
+if [ $status != 0 ]; then
+    fail "convert (exit $status)"
+elif [ $status -ge 128 ]; then
+    fail "convert (crashed, status $status)"
+elif ! grep -q "does not match" $bn.log; then
+    fail "convert (no warning)"
+else
+    pass "convert"
+fi
+
+# The written model must be internally consistent: the \data\ counts must
+# equal the number of n-gram lines in each section, and the bigram count
+# must reflect the true trie content (2051541).
+awk '
+    /^ngram [0-9]+=[0-9]+$/ { split($2, a, "="); header[a[1] + 0] = a[2] + 0; next }
+    /^\\[0-9]+-grams:$/     { sub(/^\\/, "", $1); sub(/-grams:$/, "", $1); sec = $1 + 0; next }
+    /^\\end\\$/             { sec = 0; next }
+    (sec > 0 && $0 !~ /^\\/ && NF > 0) { actual[sec]++ }
+    END {
+        ok = 1
+        for (o in header)
+            if (header[o] != actual[o]) ok = 0
+        printf "bigrams header=%d actual=%d\n", header[2], actual[2]
+        if (ok && header[2] == 2051541 && actual[2] == 2051541)
+            exit 0
+        exit 1
+    }
+' $bn.arpa
+if [ $? = 0 ]; then
+    pass "output consistent"
+else
+    fail "output consistent"
+fi
+
+rm -f $bn.arpa

--- a/test/unit/test_ngram/CMakeLists.txt
+++ b/test/unit/test_ngram/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_EXECUTABLES
   test_lm_class
   test_lm_set
   test_lm_write
+  test_lm_write_consistency
   )
 foreach(TEST_EXECUTABLE ${TEST_EXECUTABLES})
   add_executable(${TEST_EXECUTABLE} EXCLUDE_FROM_ALL ${TEST_EXECUTABLE}.c)

--- a/test/unit/test_ngram/test_lm_write_consistency.c
+++ b/test/unit/test_ngram/test_lm_write_consistency.c
@@ -1,0 +1,91 @@
+#include "lm/ngram_model.h"
+#include <pocketsphinx/logmath.h>
+#include <pocketsphinx/err.h>
+
+#include "test_macros.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Count the n-gram lines per order in an ARPA file and compare them with
+ * the counts declared in the \data\ section.  A well-formed writer must
+ * emit exactly as many lines in each \k-grams: section as it announced. */
+static int
+check_arpa_consistency(const char *path)
+{
+	FILE *fp = fopen(path, "r");
+	char line[4096];
+	int header[16];
+	int actual[16];
+	int max_order = 0;
+	int order = 0;
+	int i, k, n;
+
+	TEST_ASSERT(fp);
+	for (i = 0; i < 16; i++)
+		header[i] = actual[i] = 0;
+
+	while (fgets(line, sizeof(line), fp)) {
+		if (sscanf(line, "ngram %d=%d", &k, &n) == 2) {
+			if (k > 0 && k < 16) {
+				header[k] = n;
+				if (k > max_order)
+					max_order = k;
+			}
+			continue;
+		}
+		if (sscanf(line, "\\%d-grams:", &k) == 1) {
+			order = (k > 0 && k < 16) ? k : 0;
+			continue;
+		}
+		if (strncmp(line, "\\end\\", 5) == 0) {
+			order = 0;
+			continue;
+		}
+		if (order > 0 && line[0] != '\n' && line[0] != '\\')
+			actual[order]++;
+	}
+	fclose(fp);
+
+	TEST_ASSERT(max_order > 0);
+	for (i = 1; i <= max_order; i++) {
+		E_INFO("order %d: header %d actual %d\n", i, header[i], actual[i]);
+		TEST_EQUAL(header[i], actual[i]);
+	}
+	return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+	logmath_t *lmath;
+	ngram_model_t *model;
+
+	(void)argc;
+	(void)argv;
+	err_set_loglevel(ERR_INFO);
+
+	lmath = logmath_init(1.0001, 0, 0);
+
+	/* A consistent binary model must convert to an internally consistent
+	 * ARPA file and round-trip back without error. */
+	E_INFO("Converting consistent BIN to ARPA\n");
+	model = ngram_model_read(NULL, LMDIR "/100.lm.bin", NGRAM_BIN, lmath);
+	TEST_ASSERT(model);
+	TEST_EQUAL(0, ngram_model_write(model, "100.consistency.tmp.lm",
+					NGRAM_ARPA));
+	ngram_model_free(model);
+
+	E_INFO("Verifying \\data\\ counts match section contents\n");
+	check_arpa_consistency("100.consistency.tmp.lm");
+
+	E_INFO("Re-reading converted ARPA\n");
+	model = ngram_model_read(NULL, "100.consistency.tmp.lm", NGRAM_ARPA,
+				 lmath);
+	TEST_ASSERT(model);
+	ngram_model_free(model);
+
+	logmath_free(lmath);
+	return 0;
+}


### PR DESCRIPTION
`ngram_model_trie_write_arpa` wrote each n-gram section's count from the stored header (`base->n_counts`) and asserted that the number of n-grams recovered by walking the trie matched. When a model's header disagrees with its trie content, that assertion aborts the program; with assertions disabled the writer indexes the `raw_ngrams` array beyond the entries actually filled, dereferencing NULL word pointers or writing past the allocation.

The shipped `model/en-us/en-us.lm.bin` triggers this: its header declares 2051547 bigrams while the trie holds 2051541 (the six extra header slots are zero-padding). Converting it to ARPA aborts.

This discovers the true per-order counts by walking the trie before writing anything, and emits those counts so the output is always self-consistent. `lm_trie_fill_raw_ngram` now takes a capacity: it stops writing once the destination array is full but keeps counting, so the actual count is known without overflowing. When the header and the trie content disagree, the writer logs a warning and writes the actual counts; conversion of the en-us model now succeeds with a warning instead of aborting. Output for a consistent model is unchanged (byte-identical).

`test-lm-convert-mismatch.sh` converts the en-us model and checks that the writer warns, does not crash, and produces an ARPA whose declared counts equal the lines in each section. `test_lm_write_consistency` checks that a consistent model still writes an ARPA whose counts match its sections.

Tested on macOS (Apple clang) and Linux x86-64 (GCC 13.3); full unit and regression suite passes on both.

Fixes #502
