### PR TITLE
Document and test the forced-alignment variant-token contract

### DIFF
--- a/include/pocketsphinx/search.h
+++ b/include/pocketsphinx/search.h
@@ -332,6 +332,9 @@ int ps_add_allphone_file(ps_decoder_t *ps, const char *name, const char *path);
  *
  * Decoding proceeds as normal, though only this word sequence will be
  * recognized, with silences and alternate pronunciations inserted.
+ * An explicit dictionary variant such as `a(2)` uses only that entry's
+ * pronunciation.  A base spelling such as `a` may use any of its alternate
+ * pronunciations.  An unknown spelling such as `a(99)` causes an error.
  * Word alignments are available with ps_seg_iter().  To obtain
  * phoneme or state segmentations, you must subsequently call
  * ps_set_alignment() and re-run decoding.  It's tough son, but it's life.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -6,6 +6,8 @@ target_include_directories(test_thread_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set(TESTS
   test_acmod
   test_acmod_grow
+  test_align_text_variant
+  test_align_variant_alt
   test_alignment
   test_allphone
   test_bitvec

--- a/test/unit/test_align_text_variant.c
+++ b/test/unit/test_align_text_variant.c
@@ -1,0 +1,26 @@
+#include <pocketsphinx.h>
+
+#include "test_macros.h"
+
+int
+main(int argc, char *argv[])
+{
+    ps_config_t *config;
+    ps_decoder_t *ps;
+
+    (void)argc;
+    (void)argv;
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\""));
+    TEST_ASSERT(ps = ps_init(config));
+
+    TEST_EQUAL(-1, ps_set_align_text(ps, "a(99)"));
+    TEST_EQUAL(0, ps_set_align_text(ps, "a a(2) are are(2)"));
+
+    ps_free(ps);
+    ps_config_free(config);
+    return 0;
+}

--- a/test/unit/test_align_variant_alt.c
+++ b/test/unit/test_align_variant_alt.c
@@ -1,0 +1,37 @@
+#include <pocketsphinx.h>
+
+#include "lm/fsg_model.h"
+#include "test_macros.h"
+
+int
+main(int argc, char *argv[])
+{
+    fsg_model_t *fsg;
+    ps_config_t *config;
+    ps_decoder_t *ps;
+    int32 altwid;
+
+    (void)argc;
+    (void)argv;
+    TEST_ASSERT(config =
+                ps_config_parse_json(
+                    NULL,
+                    "hmm: \"" MODELDIR "/en-us/en-us\","
+                    "dict: \"" MODELDIR "/en-us/cmudict-en-us.dict\""));
+    TEST_ASSERT(ps = ps_init(config));
+
+    TEST_EQUAL(0, ps_set_align_text(ps, "a"));
+    TEST_ASSERT(fsg = ps_get_fsg(ps, "_align"));
+    TEST_ASSERT(fsg_model_has_alt(fsg));
+    TEST_ASSERT((altwid = fsg_model_word_id(fsg, "a(2)")) >= 0);
+    TEST_ASSERT(fsg_model_is_alt(fsg, altwid));
+
+    TEST_EQUAL(0, ps_set_align_text(ps, "a(2)"));
+    TEST_ASSERT(fsg = ps_get_fsg(ps, "_align"));
+    TEST_ASSERT(fsg_model_word_id(fsg, "a(2)") >= 0);
+    TEST_ASSERT(!fsg_model_has_alt(fsg));
+
+    ps_free(ps);
+    ps_config_free(config);
+    return 0;
+}


### PR DESCRIPTION
`ps_set_align_text()` verifies each token with an exact dictionary lookup and builds the alignment FSG from the spelling supplied. This gives forced alignment a useful variant-token contract that was neither documented nor tested:

- An explicit variant spelling such as `a(2)` is aligned with only that dictionary entry's pronunciation (in the shipped `cmudict-en-us.dict`, `a` is `AH` and `a(2)` is `EY`).
- A base spelling such as `a` remains free to use any of its alternate pronunciations.
- An unknown spelling such as `a(99)` is rejected, and `ps_set_align_text()` returns -1.

This documents the contract on `ps_set_align_text()` and adds tests for it, with no behavior change.

`test_align_text_variant` checks that an unknown variant returns -1 while a transcript of known base and variant spellings is accepted. `test_align_variant_alt` inspects the constructed `_align` FSG: a base token contributes an alternate-pronunciation transition, while an explicit variant token does not.

Fixes #503

Tested on macOS (Apple clang) and Linux x86-64 (GCC 13.3); full unit and regression suite passes on both.
