### PR TITLE
Use the MSVC pipe function spellings in pio.c

### DIFF
--- a/src/util/pio.c
+++ b/src/util/pio.c
@@ -67,6 +67,16 @@
 #include "util/strfuncs.h"
 #include "util/ckd_alloc.h"
 
+/* The MSVC/Win32 C runtime exports the pipe functions as _popen/_pclose.
+ * The POSIX spellings are declared in <stdio.h> (so HAVE_POPEN is defined
+ * and the code compiles) but are not resolvable when linking a shared
+ * library, which breaks an MSVC DLL build.  Map to the underscore
+ * spellings on Win32, matching the guard already used for _pclose. */
+#if defined(_WIN32) && !defined(__SYMBIAN32__)
+#define popen _popen
+#define pclose _pclose
+#endif
+
 #ifndef EXEEXT
 #define EXEEXT ""
 #endif
@@ -186,11 +196,7 @@ fclose_comp(FILE * fp, int32 ispipe)
 {
     if (ispipe) {
 #ifdef HAVE_POPEN
-#if defined(_WIN32) && (!defined(__SYMBIAN32__))
-        _pclose(fp);
-#else
         pclose(fp);
-#endif
 #endif
     }
     else


### PR DESCRIPTION
The Microsoft C runtime exports the pipe functions as `_popen`/`_pclose`. `pio.c` already used `_pclose` on the close side under `_WIN32`, but `fopen_comp()` called bare `popen()`, so an MSVC shared-library build failed to link:

```
pio.obj : error LNK2019: unresolved external symbol popen referenced in function fopen_comp
pocketsphinx.dll : fatal error LNK1120: 1 unresolved externals
```

This maps `popen`/`pclose` to the underscore spellings on Win32 in one place and drops the now-redundant inline `_pclose` guard, so both pipe calls use the spelling the CRT exports. The guard is inert off Win32; behavior on other platforms is unchanged.

Verified by linking the pipe construct as a DLL under MSVC: it fails with `LNK2019` before the change and links cleanly after. A non-Windows build is unaffected — the preprocessed translation unit is identical to before the change off `_WIN32`.

Fixes #505
